### PR TITLE
Chattermill Response Agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -249,3 +249,11 @@ DELAYED_JOB_SLEEP_DELAY=10
 #CAPISTRANO_DEPLOY_SERVER=
 #CAPISTRANO_DEPLOY_USER=
 #CAPISTRANO_DEPLOY_REPO_URL=
+
+##############################
+# Chattermill Slack Settings #
+# ############################
+
+# Slack webhook for Chattermill Team
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/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
+SLACK_CHANNEL=#bots

--- a/.env.example
+++ b/.env.example
@@ -255,5 +255,5 @@ DELAYED_JOB_SLEEP_DELAY=10
 # ############################
 
 # Slack webhook for Chattermill Team
-SLACK_WEBHOOK_URL=https://hooks.slack.com/services/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
-SLACK_CHANNEL=#bots
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/CHANGE-ME
+SLACK_CHANNEL='#bots'

--- a/.env.example
+++ b/.env.example
@@ -250,10 +250,11 @@ DELAYED_JOB_SLEEP_DELAY=10
 #CAPISTRANO_DEPLOY_USER=
 #CAPISTRANO_DEPLOY_REPO_URL=
 
-##############################
-# Chattermill Slack Settings #
-# ############################
+########################
+# Chattermill Settings #
+# ######################
 
 # Slack webhook for Chattermill Team
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/CHANGE-ME
 SLACK_CHANNEL='#bots'
+CHATTERMILL_AUTH_TOKEN=xxxxxx

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ unless Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('1.5.0')
   exit 1
 end
 
-gem 'ace-rails-ap', '~> 2.0.1'
+gem 'ace-rails-ap', '~> 4.1.0'
 gem 'bootstrap-kaminari-views', '~> 0.0.3'
 gem 'bundler', '>= 1.5.0'
 gem 'coffee-rails', '~> 4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ace-rails-ap (2.0.1)
+    ace-rails-ap (4.1.2)
     actioncable (5.0.1)
       actionpack (= 5.0.1)
       nio4r (~> 1.2)
@@ -596,7 +596,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ace-rails-ap (~> 2.0.1)
+  ace-rails-ap (~> 4.1.0)
   aws-sdk-core (~> 2.2.15)
   better_errors (~> 1.1)
   binding_of_caller

--- a/app/models/agents/chattermill_response_agent.rb
+++ b/app/models/agents/chattermill_response_agent.rb
@@ -146,7 +146,7 @@ module Agents
     end
 
     def parse_json_option(key)
-      options[key] = JSON.parse(options[key])
+      options[key] = JSON.parse(options[key]) unless options[key].is_a?(Hash)
     rescue
       errors.add(:base, "The '#{key}' option is an invalid JSON.")
     end
@@ -203,7 +203,7 @@ module Agents
 
     def send_slack_notification(response, event)
       link = "<https://huginn.chattermill.xyz/agents/#{event.agent_id}/events|Details>"
-      parsed_body = JSON.parse(response.body)
+      parsed_body = JSON.parse(response.body) rescue ""
       description = "Hi! I'm reporting a problem with the Chattermill agent *#{name}*"
       message = "#{description} - #{link}\n`HTTP Status: #{response.status}`\n```#{parsed_body}```"
       slack_opts = { icon_emoji: ':fire:', channel: ENV['SLACK_CHANNEL'] }

--- a/app/models/agents/chattermill_response_agent.rb
+++ b/app/models/agents/chattermill_response_agent.rb
@@ -212,7 +212,7 @@ module Agents
     end
 
     def slack_notifier
-      @slack_notifier ||= Slack::Notifier.new(ENV['SLACK_WEBHOOK_URL'], username: 'Hduginn')
+      @slack_notifier ||= Slack::Notifier.new(ENV['SLACK_WEBHOOK_URL'], username: 'Huginn')
     end
   end
 end

--- a/app/models/agents/chattermill_response_agent.rb
+++ b/app/models/agents/chattermill_response_agent.rb
@@ -1,0 +1,203 @@
+module Agents
+  class ChattermillResponseAgent < Agent
+    include WebRequestConcern
+    include FormConfigurable
+
+    MIME_RE = /\A\w+\/.+\z/
+    HTTP_METHOD = "post"
+    PROTOCOLS = %w(http https)
+    API_ENDPOINT = "/webhooks/responses"
+    DOMAINS = [
+      { text: "Production", id: "app.chattermill.xyz" },
+      { text: "Staging", id: "staging.chattermill.xyz" },
+      { text: "Local (lvh.me)", id: "lvh.me:3000" },
+      { text: "localhost", id: "localhost:3000" }
+    ]
+    BASIC_OPTIONS = %w(comment score kind stream created_at user_meta segments)
+
+    can_dry_run!
+    no_bulk_receive!
+    default_schedule "never"
+
+    description do
+      <<-MD
+        A Chattermill Response Agent receives events from other agents (or runs periodically), merges those events with the [Liquid-interpolated](https://github.com/cantino/huginn/wiki/Formatting-Events-using-Liquid) contents of `payload`, and sends the results as POST (or GET) requests to a specified url.  To skip merging in the incoming event, but still send the interpolated payload, set `no_merge` to `true`.
+
+        The `post_url` field must specify where you would like to send requests. Please include the URI scheme (`http` or `https`).
+
+        The `method` used can be any of `get`, `post`, `put`, `patch`, and `delete`.
+
+        By default, non-GETs will be sent with form encoding (`application/x-www-form-urlencoded`).
+
+        Change `content_type` to `json` to send JSON instead.
+
+        Change `content_type` to `xml` to send XML, where the name of the root element may be specified using `xml_root`, defaulting to `post`.
+
+        When `content_type` contains a [MIME](https://en.wikipedia.org/wiki/Media_type) type, and `payload` is a string, its interpolated value will be sent as a string in the HTTP request's body and the request's `Content-Type` HTTP header will be set to `content_type`. When `payload` is a string `no_merge` has to be set to `true`.
+
+        If `emit_events` is set to `true`, the server response will be emitted as an Event and can be fed to a WebsiteAgent for parsing (using its `data_from_event` and `type` options). No data processing
+        will be attempted by this Agent, so the Event's "body" value will always be raw text.
+        The Event will also have a "headers" hash and a "status" integer value.
+        Set `event_headers_style` to one of the following values to normalize the keys of "headers" for downstream agents' convenience:
+
+          * `capitalized` (default) - Header names are capitalized; e.g. "Content-Type"
+          * `downcased` - Header names are downcased; e.g. "content-type"
+          * `snakecased` - Header names are snakecased; e.g. "content_type"
+          * `raw` - Backward compatibility option to leave them unmodified from what the underlying HTTP library returns.
+
+        Other Options:
+
+          * `headers` - When present, it should be a hash of headers to send with the request.
+          * `basic_auth` - Specify HTTP basic auth parameters: `"username:password"`, or `["username", "password"]`.
+          * `disable_ssl_verification` - Set to `true` to disable ssl verification.
+          * `user_agent` - A custom User-Agent name (default: "Faraday v#{Faraday::VERSION}").
+      MD
+    end
+
+    event_description <<-MD
+      Events look like this:
+        {
+          "status": 200,
+          "headers": {
+            "Content-Type": "text/html",
+            ...
+          },
+          "body": "<html>Some data...</html>"
+        }
+    MD
+
+    def default_options
+      {
+        'protocol' => 'https',
+        'domain' => 'app.chattermill.xyz',
+        'comment' => '{{ data.comment }}',
+        'score' => '{{ data.score }}',
+        'kind' => 'review',
+        'created_at' => '{{ data.date }}',
+        'user_meta' => '{}',
+        'segments' => '{}',
+        'extra_fields' => '{}',
+        'emit_events' => 'false'
+      }
+    end
+
+    def working?
+      last_receive_at && last_receive_at > interpolated['expected_receive_period_in_days'].to_i.days.ago && !recent_error_logs?
+    end
+
+    def http_method
+      HTTP_METHOD
+    end
+
+    form_configurable :protocol, type: :array, values: PROTOCOLS
+    form_configurable :domain, roles: :completable
+    form_configurable :organization_subdomain
+    form_configurable :auth_token
+    form_configurable :comment
+    form_configurable :score
+    form_configurable :kind
+    form_configurable :stream
+    form_configurable :created_at
+    form_configurable :user_meta, type: :text, ace: true
+    form_configurable :segments, type: :text, ace: true
+    form_configurable :extra_fields, type: :text, ace: true
+    form_configurable :emit_events, :array, values: %w(true false)
+    form_configurable :expected_receive_period_in_days
+
+    def complete_domain
+      DOMAINS
+    end
+
+    def validate_options
+      if options['protocol'].blank? || !PROTOCOLS.include?(options['protocol'])
+        errors.add(:base, "The 'protocol' option is required and must be set to 'http' or 'https'")
+      end
+      if options['domain'].blank?
+        errors.add(:base, "The 'domain' option is required.")
+      end
+      if options['organization_subdomain'].blank?
+        errors.add(:base, "The 'organization_subdomain' option is required.")
+      end
+      if options['auth_token'].blank?
+        errors.add(:base, "The 'auth_token' option is required.")
+      end
+      if options['expected_receive_period_in_days'].blank?
+        errors.add(:base, "The 'expected_receive_period_in_days' option is required.")
+      end
+
+      if options.has_key?('emit_events') && boolify(options['emit_events']).nil?
+        errors.add(:base, "if provided, emit_events must be true or false")
+      end
+
+      validate_web_request_options!
+    end
+
+    def receive(incoming_events)
+      incoming_events.each do |event|
+        interpolate_with(event) do
+          outgoing = interpolated.slice(*BASIC_OPTIONS)
+          outgoing.merge!(interpolated['extra_fields'].presence || {})
+
+          handle outgoing, event, headers(auth_header(interpolated['auth_token']))
+        end
+      end
+    end
+
+    def check
+      outgoing = interpolated.slice(*BASIC_OPTIONS)
+      outgoing.merge!(interpolated['extra_fields'].presence || {})
+
+      handle outgoing, headers(auth_header(interpolated['auth_token']))
+    end
+
+    private
+
+    def normalize_response_headers(headers)
+      case interpolated['event_headers_style']
+      when nil, '', 'capitalized'
+        normalize = ->name {
+          name.gsub(/(?:\A|(?<=-))([[:alpha:]])|([[:alpha:]]+)/) {
+            $1 ? $1.upcase : $2.downcase
+          }
+        }
+      when 'downcased'
+        normalize = :downcase.to_proc
+      when 'snakecased', nil
+        normalize = ->name { name.tr('A-Z-', 'a-z_') }
+      when 'raw'
+        normalize = ->name { name }  # :itself.to_proc in Ruby >= 2.2
+      else
+        raise ArgumentError, "if provided, event_headers_style must be 'capitalized', 'downcased', 'snakecased' or 'raw'"
+      end
+
+      headers.each_with_object({}) { |(key, value), hash|
+        hash[normalize[key]] = value
+      }
+    end
+
+    def post_url(event = Event.new)
+      event_options = interpolated(event.payload)
+      protocol = event_options['protocol']
+      host = "#{event_options['organization_subdomain']}.#{event_options['domain']}"
+
+      "#{protocol}://#{host}#{API_ENDPOINT}"
+    end
+
+    def auth_header(token)
+      { "Authorization" => "Bearer #{token}" }
+    end
+
+    def handle(data, event = Event.new, headers)
+      url = post_url(event)
+      headers['Content-Type'] = 'application/json; charset=utf-8'
+      body = data.to_json
+
+      response = faraday.run_request(http_method.to_sym, url, body, headers)
+      return unless boolify(interpolated['emit_events'])
+
+      create_event(payload: { body: response.body,
+                              headers: normalize_response_headers(response.headers),
+                              status: response.status })
+    end
+  end
+end

--- a/app/presenters/form_configurable_agent_presenter.rb
+++ b/app/presenters/form_configurable_agent_presenter.rb
@@ -19,8 +19,9 @@ class FormConfigurableAgentPresenter < Decorator
     html_options = {role: (data[:roles] + ['form-configurable']).join(' '), data: {attribute: attribute}}
 
     case data[:type]
-    when :text
+    when :text, :json
       @view.content_tag 'div' do
+        value = Utils.pretty_jsonify(value) if value.is_a?(Hash) && data[:type] == :json
         @view.concat @view.text_area_tag("agent[options][#{attribute}]", value, html_options.merge(class: 'form-control', rows: 3))
         if data[:ace].present?
           ace_options = { source: "[name='agent[options][#{attribute}]']", mode: '', theme: ''}.deep_symbolize_keys!

--- a/spec/models/agents/chattermill_response_agent_spec.rb
+++ b/spec/models/agents/chattermill_response_agent_spec.rb
@@ -11,10 +11,12 @@ describe Agents::ChattermillResponseAgent do
   end
 
   before do
+    stub.proxy(ENV).[](anything)
+    stub(ENV).[]('CHATTERMILL_AUTH_TOKEN') { 'token-123' }
+
     @valid_options = {
       'organization_subdomain' => 'foo',
       'expected_receive_period_in_days' => 1,
-      'auth_token' => 'token-123',
       'comment' => '{{ data.comment }}',
       'segments' => segments.to_json,
       'user_meta' => user_meta.to_json,
@@ -160,8 +162,7 @@ describe Agents::ChattermillResponseAgent do
 
     describe "slack notification" do
       before do
-        @checker.options['auth_token'] = 'invalid'
-        stub.proxy(ENV).[](anything)
+        stub(ENV).[]('CHATTERMILL_AUTH_TOKEN') { 'invalid' }
         stub(ENV).[]('SLACK_WEBHOOK_URL') { 'http://slack.webhook/abc' }
         stub(ENV).[]('SLACK_CHANNEL') { '#mychannel' }
       end
@@ -198,11 +199,6 @@ describe Agents::ChattermillResponseAgent do
 
     it "should validate presence of expected_receive_period_in_days" do
       @checker.options['expected_receive_period_in_days'] = ""
-      expect(@checker).not_to be_valid
-    end
-
-    it "should validate presence of auth_token" do
-      @checker.options['auth_token'] = ""
       expect(@checker).not_to be_valid
     end
 

--- a/spec/models/agents/chattermill_response_agent_spec.rb
+++ b/spec/models/agents/chattermill_response_agent_spec.rb
@@ -1,0 +1,274 @@
+require 'rails_helper'
+require 'ostruct'
+
+describe Agents::ChattermillResponseAgent do
+  let(:segments) do
+    { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => '{{data.segment}}' } }
+  end
+
+  let(:user_meta) do
+    { 'meta_id' => { 'type' => 'text', 'name' => 'Meta Id' } }
+  end
+
+  before do
+    @valid_options = {
+      'organization_subdomain' => 'foo',
+      'expected_receive_period_in_days' => 1,
+      'auth_token' => 'token-123',
+      'comment' => '{{ data.comment }}',
+      'segments' => segments.to_json,
+      'user_meta' => user_meta.to_json,
+      'extra_fields' => '{}'
+    }
+    @valid_params = {
+      name: "somename",
+      options: @valid_options
+    }
+
+    @checker = Agents::ChattermillResponseAgent.new(@valid_params)
+    @checker.user = users(:jane)
+    @checker.save!
+
+    @event = Event.new
+    @event.agent = agents(:jane_weather_agent)
+    @event.payload = {
+      'somekey' => 'somevalue',
+      'data' => {
+        'comment' => 'Test Comment'
+      }
+    }
+    @requests = 0
+    @sent_requests = Hash.new { |hash, method| hash[method] = [] }
+
+    stub_request(:any, /:/).to_return { |request|
+      method = request.method
+      @requests += 1
+      @sent_requests[method] << req = OpenStruct.new(uri: request.uri, headers: request.headers)
+      req.data = ActiveSupport::JSON.decode(request.body)
+      if request.headers['Authorization'] =~ /invalid/
+        { status: 401, body: '{"error": "Unauthorized"}', headers: { 'Content-type' => 'application/json' } }
+      else
+        { status: 201, body: '{}', headers: { 'Content-type' => 'application/json' } }
+      end
+    }
+  end
+
+  it_behaves_like WebRequestConcern
+
+  it 'renders the description markdown without errors' do
+    expect { @checker.description }.not_to raise_error
+  end
+
+  describe "making requests" do
+    it "makes POST requests" do
+      expect(@checker).to be_valid
+      @checker.check
+      expect(@requests).to eq(1)
+      expect(@sent_requests[:post].length).to eq(1)
+    end
+
+    it "uses the correct URI" do
+      @checker.check
+      uri = @sent_requests[:post].first.uri.to_s
+      expect(uri).to eq("http://foo.localhost:3000/webhooks/responses")
+    end
+
+    it "generates the authorization header" do
+      @checker.check
+      auth_header = @sent_requests[:post].first.headers['Authorization']
+      expect(auth_header).to eq("Bearer token-123")
+    end
+  end
+
+  describe "#receive" do
+    it "can handle multiple events" do
+      event1 = Event.new
+      event1.agent = agents(:bob_weather_agent)
+      event1.payload = {
+        'xyz' => 'value1',
+        'data' => {
+          'segment' => 'My Segment'
+        }
+      }
+
+      expect {
+        @checker.receive([@event, event1])
+      }.to change { @sent_requests[:post].length }.by(2)
+
+      expected = {
+        'comment' => 'Test Comment',
+        'segments' => { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => '' } },
+        'user_meta' => user_meta
+      }
+      expect(@sent_requests[:post][0].data).to eq(expected)
+
+      expected = {
+        'comment' => '',
+        'segments' => { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => 'My Segment' } },
+        'user_meta' => user_meta
+      }
+      expect(@sent_requests[:post][1].data).to eq(expected)
+    end
+  end
+
+  describe "#check" do
+    it "sends data as a POST request" do
+      expect {
+        @checker.check
+      }.to change { @sent_requests[:post].length }.by(1)
+
+      expected = {
+        'comment' => '',
+        'segments' => { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => '' } },
+        'user_meta' => user_meta
+      }
+      expect(@sent_requests[:post][0].data).to eq(expected)
+    end
+
+    describe "emitting events" do
+      context "when emit_events is not set to true" do
+        it "does not emit events" do
+          expect {
+            @checker.check
+          }.not_to change { @checker.events.count }
+        end
+      end
+
+      context "when emit_events is set to true" do
+        before do
+          @checker.options['emit_events'] = 'true'
+        end
+
+        it "emits the response status" do
+          expect {
+            @checker.check
+          }.to change { @checker.events.count }.by(1)
+          expect(@checker.events.last.payload['status']).to eq 201
+        end
+
+        it "emits the body" do
+          @checker.check
+          expect(@checker.events.last.payload['body']).to eq '{}'
+        end
+
+        it "emits the response headers capitalized by default" do
+          @checker.check
+          expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'application/json' })
+        end
+      end
+    end
+
+    describe "slack notification" do
+      before do
+        @checker.options['auth_token'] = 'invalid'
+        stub.proxy(ENV).[](anything)
+        stub(ENV).[]('SLACK_WEBHOOK_URL') { 'http://slack.webhook/abc' }
+        stub(ENV).[]('SLACK_CHANNEL') { '#mychannel' }
+      end
+
+      it "sends a slack notification" do
+        slack = mock
+        mock(slack).ping(/Unauthorized/, { icon_emoji: ':fire:', channel: '#mychannel' }) { true }
+        mock(Slack::Notifier).new('http://slack.webhook/abc', { username: 'Huginn' }) { slack }
+        @checker.check
+      end
+    end
+  end
+
+  describe "#working?" do
+    it "checks if events have been received within expected receive period" do
+      expect(@checker).not_to be_working
+      described_class.async_receive @checker.id, [@event.id]
+      expect(@checker.reload).to be_working
+      two_days_from_now = 2.days.from_now
+      stub(Time).now { two_days_from_now }
+      expect(@checker.reload).not_to be_working
+    end
+  end
+
+  describe "validation" do
+    before do
+      expect(@checker).to be_valid
+    end
+
+    it "should validate presence of post_url" do
+      @checker.options['organization_subdomain'] = ""
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate presence of expected_receive_period_in_days" do
+      @checker.options['expected_receive_period_in_days'] = ""
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate presence of auth_token" do
+      @checker.options['auth_token'] = ""
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate segments as a hash" do
+      @checker.options['segments'] = {}
+      @checker.save
+      expect(@checker).to be_valid
+    end
+
+    it "should validate segments as a JSON string" do
+      @checker.options['segments'] = segments.to_json
+      @checker.save
+      expect(@checker).to be_valid
+
+      @checker.options['segments'] = "invalid json"
+      @checker.save
+      expect(@checker).to_not be_valid
+    end
+
+    it "should validate user_meta as a hash" do
+      @checker.options['user_meta'] = {}
+      @checker.save
+      expect(@checker).to be_valid
+    end
+
+    it "should validate user_meta as a JSON string" do
+      @checker.options['user_meta'] = segments.to_json
+      @checker.save
+      expect(@checker).to be_valid
+
+      @checker.options['user_meta'] = "invalid json"
+      @checker.save
+      expect(@checker).to_not be_valid
+    end
+
+    it "should validate extra_fields as a hash" do
+      @checker.options['extra_fields'] = {}
+      @checker.save
+      expect(@checker).to be_valid
+    end
+
+    it "should validate extra_fields as a JSON string" do
+      @checker.options['extra_fields'] = '{}'
+      @checker.save
+      expect(@checker).to be_valid
+
+      @checker.options['extra_fields'] = "invalid json"
+      @checker.save
+      expect(@checker).to_not be_valid
+    end
+
+    it "requires emit_events to be true or false" do
+      @checker.options['emit_events'] = 'what?'
+      expect(@checker).not_to be_valid
+
+      @checker.options.delete('emit_events')
+      expect(@checker).to be_valid
+
+      @checker.options['emit_events'] = 'true'
+      expect(@checker).to be_valid
+
+      @checker.options['emit_events'] = 'false'
+      expect(@checker).to be_valid
+
+      @checker.options['emit_events'] = true
+      expect(@checker).to be_valid
+    end
+  end
+end

--- a/spec/presenters/form_configurable_agent_presenter_spec.rb
+++ b/spec/presenters/form_configurable_agent_presenter_spec.rb
@@ -9,10 +9,12 @@ describe FormConfigurableAgentPresenter do
     form_configurable :text, type: :text, roles: :completable
     form_configurable :boolean, type: :boolean
     form_configurable :array, type: :array, values: [1, 2, 3]
+    form_configurable :json, type: :json
   end
 
   before(:all) do
-    @presenter = FormConfigurableAgentPresenter.new(FormConfigurableAgentPresenterAgent.new, ActionController::Base.new.view_context)
+    agent = FormConfigurableAgentPresenterAgent.new(options: { json: {} })
+    @presenter = FormConfigurableAgentPresenter.new(agent, ActionController::Base.new.view_context)
   end
 
   it "works for the type :string" do
@@ -36,6 +38,14 @@ describe FormConfigurableAgentPresenter do
   it "works for the type :array" do
     expect(@presenter.option_field_for(:array)).to(
       have_tag('input', with: {:'data-attribute' => 'array', role: 'completable form-configurable', type: 'text', name: 'agent[options][array]'})
+    )
+  end
+
+  it "works for the type :json" do
+    expect(@presenter.option_field_for(:json)).to(
+      have_tag('textarea',
+               with: {:'data-attribute' => 'json', role: 'form-configurable', name: 'agent[options][json]'},
+               seen: "{\n}")
     )
   end
 end


### PR DESCRIPTION
- [x] Add new agent
- [x] Add specs for new Chattermill Agent
- [x] Update ace editor (solves jump/scroll issue with onClick/focus events)
- [x] Add :json support to `form_configurable` & update specs

## Screenshots
### Main Options

<img width="640" alt="screen shot 2017-03-01 at 12 58 49 pm" src="https://cloud.githubusercontent.com/assets/75487/23471217/f8cb3c30-fe7e-11e6-91fa-3a97a523745c.png">

### JSON options With ace editor

<img width="613" alt="screen shot 2017-03-01 at 12 59 08 pm" src="https://cloud.githubusercontent.com/assets/75487/23471246/0ea65eb8-fe7f-11e6-8962-9a1c19635d8d.png">

### Extra fields
Allows to build additional fields for the Response, e.g: `{ approved: true }`

<img width="624" alt="screen shot 2017-03-01 at 12 59 19 pm" src="https://cloud.githubusercontent.com/assets/75487/23471300/3e352c7c-fe7f-11e6-90ca-73ff879743cc.png">