### PR TITLE
Correctly add products attribute when needed

### DIFF
--- a/app/models/agents/appfigures_reviews_agent.rb
+++ b/app/models/agents/appfigures_reviews_agent.rb
@@ -77,7 +77,7 @@ module Agents
     private
 
     def build_default_options
-      options['filter'] << "&#{options['products']}" if options['products'].present?
+      options['filter'] << "&products=#{options['products']}" if options['products'].present?
       options['url'] = "https://api.appfigures.com/v2/reviews"
       options['url'] << "#{options['filter']}" if options['filter'].present?
       options['headers'] = auth_header(


### PR DESCRIPTION
We were not adding `products` options correctly to the URL