### PR TITLE
Use Sidekiq to process jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,6 +124,7 @@ gem 'rails', '~> 5.0.1'
 gem 'rufus-scheduler', '~> 3.3.2', require: false
 gem 'sass-rails',   '~> 5.0.6'
 gem 'select2-rails', '~> 3.5.4'
+gem 'sidekiq'
 gem 'spectrum-rails'
 gem 'therubyracer', '~> 0.12.2'
 gem 'typhoeus', '~> 0.6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
     coffee-script-source (1.10.0)
     colorize (0.7.7)
     concurrent-ruby (1.0.3)
+    connection_pool (2.2.1)
     cookiejar (0.3.2)
     coveralls (0.7.12)
       multi_json (~> 1.10)
@@ -417,6 +418,8 @@ GEM
     rack (2.0.1)
     rack-livereload (0.3.16)
       rack
+    rack-protection (2.0.0)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.1)
@@ -453,6 +456,7 @@ GEM
       ffi (>= 0.5.0)
     rb-kqueue (0.2.4)
       ffi (>= 0.5.0)
+    redis (3.3.3)
     ref (2.0.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
@@ -510,6 +514,11 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (3.0.0)
       activesupport (>= 4.0.0)
+    sidekiq (5.0.2)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.3, >= 3.3.3)
     signet (0.6.0)
       addressable (~> 2.3)
       extlib (~> 0.9)
@@ -695,6 +704,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.6)
   select2-rails (~> 3.5.4)
   shoulda-matchers
+  sidekiq
   slack-notifier (~> 1.0.0)
   spectrum-rails
   spring (~> 1.7.2)
@@ -718,7 +728,7 @@ DEPENDENCIES
   xmpp4r (~> 0.5.6)
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/Procfile
+++ b/Procfile
@@ -3,12 +3,13 @@
 ###############################
 
 # Procfile for development using the new threaded worker (scheduler, twitter stream and delayed job)
-web: bundle exec rails server -p ${PORT-3000} -b ${IP-0.0.0.0}
-jobs: bundle exec rails runner bin/threaded.rb
+# web: bundle exec rails server -p ${PORT-3000} -b ${IP-0.0.0.0}
+# jobs: bundle exec rails runner bin/threaded.rb
 
 # Old version with separate processes (use this if you have issues with the threaded version)
-# web: bundle exec rails server
-# schedule: bundle exec rails runner bin/schedule.rb
+web: bundle exec rails server
+schedule: bundle exec rails runner bin/schedule.rb
+sidekiq: bundle exec sidekiq
 # twitter: bundle exec rails runner bin/twitter_stream.rb
 # dj: bundle exec script/delayed_job run
 

--- a/Procfile
+++ b/Procfile
@@ -7,7 +7,7 @@
 # jobs: bundle exec rails runner bin/threaded.rb
 
 # Old version with separate processes (use this if you have issues with the threaded version)
-web: bundle exec rails server
+web: bundle exec rails server -p ${PORT-3000} -b ${IP-0.0.0.0}
 schedule: bundle exec rails runner bin/schedule.rb
 sidekiq: bundle exec sidekiq
 # twitter: bundle exec rails runner bin/twitter_stream.rb

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,6 @@ module Huginn
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
 
-    config.active_job.queue_adapter = :delayed_job
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Redis.current = Redis.new(url: ENV['REDIS_URL'] || 'redis://127.0.0.1:6379')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Huginn::Application.routes.draw do
+  require 'sidekiq/web'
+  mount Sidekiq::Web => '/sidekiq'
+
   resources :agents do
     member do
       post :run
@@ -100,12 +103,12 @@ Huginn::Application.routes.draw do
   post  "/users/:user_id/update_location/:secret" => "web_requests#update_location" # legacy
 
   devise_for :users,
-             controllers: { 
+             controllers: {
                omniauth_callbacks: 'omniauth_callbacks',
                registrations: 'users/registrations'
              },
              sign_out_via: [:post, :delete]
-  
+
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Huginn::Application.routes.draw do
   require 'sidekiq/web'
-  mount Sidekiq::Web => '/sidekiq'
+
+  authenticate :user do
+    mount Sidekiq::Web => '/sidekiq'
+  end
 
   resources :agents do
     member do

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,20 @@
+# Sample configuration file for Sidekiq.
+# Options here can still be overridden by cmd line args.
+# Place this file at config/sidekiq.yml and Sidekiq will
+# pick it up automatically.
+---
+:verbose: false
+:concurrency: 10
+
+# Set timeout to 8 on Heroku, longer if you manage your own systems.
+:timeout: 8
+
+# Sidekiq will run this file through ERB when reading it so you can
+# even put in dynamic logic, like a host-specific queue.
+# http://www.mikeperham.com/2013/11/13/advanced-sidekiq-host-specific-queues/
+:queues:
+  - default
+
+# you can override concurrency based on environment
+production:
+  :concurrency: 20

--- a/deployment/chattermill/Procfile
+++ b/deployment/chattermill/Procfile
@@ -1,0 +1,11 @@
+# This setup uses an unicorn config similar to default one but suitable to use on Dokku,
+# it can be found st deployment/chattermill/unicorn.rb
+
+# Also, this setup uses the old version Procfile structure with separate processes
+# so we can use Sidekiq and keep DelayedJob for schedule.
+web: bundle exec unicorn -p $PORT -c ./deployment/chattermill/unicorn.rb
+schedule: bundle exec rails runner bin/schedule.rb
+sidekiq: bundle exec sidekiq -C config/sidekiq.yml
+
+# Uncommnet next line to enable twitter stream if needed
+# twitter: bundle exec rails runner bin/twitter_stream.rb

--- a/deployment/chattermill/Procfile
+++ b/deployment/chattermill/Procfile
@@ -1,7 +1,7 @@
-# This setup uses an unicorn config similar to default one but suitable to use on Dokku,
-# it can be found st deployment/chattermill/unicorn.rb
+# This setup uses an unicorn config similar to default one but suitable for use with Dokku,
+# it can be found at deployment/chattermill/unicorn.rb
 
-# Also, this setup uses the old version Procfile structure with separate processes
+# Also, this setup uses the old Procfile structure with separate processes
 # so we can use Sidekiq and keep DelayedJob for schedule.
 web: bundle exec unicorn -p $PORT -c ./deployment/chattermill/unicorn.rb
 schedule: bundle exec rails runner bin/schedule.rb

--- a/deployment/chattermill/unicorn.rb
+++ b/deployment/chattermill/unicorn.rb
@@ -1,0 +1,24 @@
+require "net/http"
+
+worker_processes Integer(ENV["WEB_CONCURRENCY"] || 2)
+timeout 15
+preload_app true
+
+before_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn master intercepting TERM and sending myself QUIT instead'
+    Process.kill 'QUIT', Process.pid
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.connection.disconnect!
+end
+
+after_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Tested with basic Sidekiq setup and looks like everything is working.

### TODO:

- [x] Add Redis config
- [x] Add Sidekiq config file and/or number of process & workers
- [x] Setup works with dokku? // (works with foreman locally) // Works on DO
- [x] Sidekiq UI on /sidekiq

### Notes:

Run with chattermill configs:
`foreman start -f deployment/chattermill/Procfile -d .`

Also, `foreman start` will use Sidekiq too, but web process uses Webrick.

### How to install on DO
We need to install Redis on DO droplet and scale dokku processes to boot up sidekiq and scheduler

```
----- Redis -----
dokku plugin:install https://github.com/dokku/dokku-redis.git redis
dokku redis:create huginn
dokku redis:link huginn huginn
-------------------------------

# Change Profile
dokku config:set PROCFILE_PATH=deployment/chattermill/Procfile

# Scale workers
dokku ps:scale huginn schedule=1 sidekiq=1
```


