### PR TITLE
Fix events sorting

### DIFF
--- a/app/controllers/agents/dry_runs_controller.rb
+++ b/app/controllers/agents/dry_runs_controller.rb
@@ -4,10 +4,13 @@ module Agents
 
     def index
       @events = if params[:agent_id]
-                  current_user.agents.find_by(id: params[:agent_id]).received_events.limit(5)
+                  current_user.agents
+                              .find_by(id: params[:agent_id])
+                              .received_events
+                              .reorder("events.id DESC NULLS LAST").limit(5)
                 elsif params[:source_ids]
                   Event.where(agent_id: current_user.agents.where(id: params[:source_ids]).pluck(:id))
-                       .order("id DESC").limit(5)
+                       .reorder("id DESC NULLS LAST").limit(5)
                 else
                   []
                 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,10 +4,12 @@ class EventsController < ApplicationController
   def index
     if params[:agent_id]
       @agent = current_user.agents.find(params[:agent_id])
-      @events = @agent.events.page(params[:page])
+      @events = @agent.events
     else
-      @events = current_user.events.preload(:agent).page(params[:page])
+      @events = current_user.events.preload(:agent)
     end
+
+    @events = @events.page(params[:page]).reorder("events.id DESC NULLS LAST")
 
     respond_to do |format|
       format.html


### PR DESCRIPTION
This should improve performance because PG planner was doing some `Materialize` operation.

````
EXPLAIN ANALYZE SELECT  "events".* FROM "events" INNER JOIN "agents" ON "events"."agent_id" = "agents"."id" INNER JOIN "links" ON "agents"."id" = "links"."source_id" WHERE "links"."receiver_id" = 258 ORDER BY events.id desc LIMIT 5;
                                                                           QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.57..159.34 rows=5 width=910) (actual time=22934.993..22934.993 rows=0 loops=1)
   ->  Nested Loop  (cost=0.57..215729.39 rows=6794 width=910) (actual time=22934.991..22934.991 rows=0 loops=1)
         Join Filter: (agents.id = events.agent_id)
         ->  Index Scan Backward using events_pkey on events  (cost=0.43..197578.02 rows=1209257 width=910) (actual time=1.983..22657.626 rows=1209257 loops=1)
         ->  Materialize  (cost=0.15..12.52 rows=1 width=8) (actual time=0.000..0.000 rows=0 loops=1209257)
               ->  Nested Loop  (cost=0.15..12.51 rows=1 width=8) (actual time=0.045..0.045 rows=0 loops=1)
                     ->  Seq Scan on links  (cost=0.00..4.34 rows=1 width=4) (actual time=0.045..0.045 rows=0 loops=1)
                           Filter: (receiver_id = 258)
                           Rows Removed by Filter: 187
                     ->  Index Only Scan using agents_pkey on agents  (cost=0.15..8.17 rows=1 width=4) (never executed)
                           Index Cond: (id = links.source_id)
                           Heap Fetches: 0
 Planning time: 0.611 ms
 Execution time: 22935.064 ms
(14 rows)
```

```
EXPLAIN ANALYZE SELECT  "events".* FROM "events" INNER JOIN "agents" ON "events"."agent_id" = "agents"."id" INNER JOIN "links" ON "agents"."id" = "links"."source_id" WHERE "links"."receiver_id" = 258 ORDER BY events.id desc NULLS LAST LIMIT 5;
                                                                   QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=2161.83..2161.84 rows=5 width=910) (actual time=0.068..0.068 rows=0 loops=1)
   ->  Sort  (cost=2161.83..2178.82 rows=6794 width=910) (actual time=0.066..0.066 rows=0 loops=1)
         Sort Key: events.id DESC NULLS LAST
         Sort Method: quicksort  Memory: 25kB
         ->  Nested Loop  (cost=0.57..2048.99 rows=6794 width=910) (actual time=0.025..0.025 rows=0 loops=1)
               ->  Nested Loop  (cost=0.15..12.51 rows=1 width=8) (actual time=0.025..0.025 rows=0 loops=1)
                     ->  Seq Scan on links  (cost=0.00..4.34 rows=1 width=4) (actual time=0.025..0.025 rows=0 loops=1)
                           Filter: (receiver_id = 258)
                           Rows Removed by Filter: 187
                     ->  Index Only Scan using agents_pkey on agents  (cost=0.15..8.17 rows=1 width=4) (never executed)
                           Index Cond: (id = links.source_id)
                           Heap Fetches: 0
               ->  Index Scan using index_events_on_agent_id_and_created_at on events  (cost=0.43..1976.90 rows=5957 width=910) (never executed)
                     Index Cond: (agent_id = agents.id)
 Planning time: 23.508 ms
 Execution time: 0.500 ms
(16 rows)
````