### PR TITLE
Increase default timeout for unicorn and allow change it with ENV var

### DIFF
--- a/deployment/chattermill/unicorn.rb
+++ b/deployment/chattermill/unicorn.rb
@@ -1,7 +1,7 @@
 require "net/http"
 
 worker_processes Integer(ENV["WEB_CONCURRENCY"] || 2)
-timeout 15
+timeout Integer(ENV["WEB_TIMEOUT"] || 30)
 preload_app true
 
 before_fork do |server, worker|


### PR DESCRIPTION
- [x] Increase default timeout to 30s
- [x] Allow to change timeout value using `WEB_TIMEOUT` environment variable. 