### PR TITLE
Fix error when memory of S3 Agent is empty.

### DIFF
--- a/app/models/agents/s3_agent.rb
+++ b/app/models/agents/s3_agent.rb
@@ -167,7 +167,7 @@ module Agents
 
       new_memory = contents.dup
 
-      memory['seen_contents'].each do |key, etag|
+      (memory['seen_contents'] || {}).each do |key, etag|
         if contents[key].blank?
           create_event payload: get_file_pointer(key).merge(event_type: :removed)
         elsif contents[key] != etag


### PR DESCRIPTION
Somehow after editing the Agent,  memory gets deleted. I tried locally with a fresh agent and it worked, but after some edit, it started to fail. This fixes the problem.