### PR TITLE
Chattermill agent validations

### DIFF
--- a/app/models/agents/chattermill_response_agent.rb
+++ b/app/models/agents/chattermill_response_agent.rb
@@ -188,6 +188,8 @@ module Agents
     end
 
     def handle(data, event = Event.new, headers)
+      return unless valid_payload?(data, event)
+
       url = request_url(event)
       headers['Content-Type'] = 'application/json; charset=utf-8'
       body = data.to_json
@@ -200,6 +202,13 @@ module Agents
                               headers: normalize_response_headers(response.headers),
                               status: response.status,
                               source_event: event.id })
+    end
+
+    def valid_payload?(data, event)
+      validator = ResponseValidator.new(data)
+      log(validator.errors.merge(source_event: event.id)) unless validator.valid?
+
+      validator.valid?
     end
 
     def send_slack_notification(response, event)
@@ -231,6 +240,32 @@ module Agents
 
     def slack_notifier
       @slack_notifier ||= Slack::Notifier.new(ENV['SLACK_WEBHOOK_URL'], username: 'Huginn')
+    end
+
+    class ResponseValidator
+      include ActiveModel::Validations
+
+      attr_reader :data
+
+      validates :score, presence: true, numericality: true, if: :validate_score?
+
+      def initialize(data)
+        @data = data
+      end
+
+      def data_type
+        @data['data_type']
+      end
+
+      def score
+        @data['score']
+      end
+
+      private
+
+      def validate_score?
+        data_type.in?(%w[nps review csat])
+      end
     end
   end
 end

--- a/app/models/agents/chattermill_response_agent.rb
+++ b/app/models/agents/chattermill_response_agent.rb
@@ -206,7 +206,7 @@ module Agents
 
     def valid_payload?(data, event)
       validator = ResponseValidator.new(data)
-      log(validator.errors.merge(source_event: event.id)) unless validator.valid?
+      error(validator.errors.messages.merge(source_event: event.id).to_json) unless validator.valid?
 
       validator.valid?
     end
@@ -229,7 +229,7 @@ module Agents
             text: description,
             fallback: description,
             mrkdwn_in: [
-                "text"
+              "text"
             ]
           }
         ]
@@ -254,11 +254,11 @@ module Agents
       end
 
       def data_type
-        @data['data_type']
+        data['kind']
       end
 
       def score
-        @data['score']
+        data['score']
       end
 
       private


### PR DESCRIPTION
https://trello.com/c/agDU45Ct/432-add-better-validation-rules-for-chattermill-agent

- [x] Added `ResponseValidator` class to handle validations. We can add more there if needed.
- [x] Log message with validation error (skip slack notification and event creation).
- [x] Specs.