### PR TITLE
Added rake task for re-emit falied events from Chattermill agent.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,7 @@ end
 gem 'ace-rails-ap', '~> 4.1.0'
 gem 'bootstrap-kaminari-views', '~> 0.0.3'
 gem 'bundler', '>= 1.5.0'
+gem 'chronic', require: false
 gem 'coffee-rails', '~> 4.2'
 gem 'daemons', '~> 1.1.9'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -686,6 +686,7 @@ DEPENDENCIES
   capybara (~> 2.13.0)
   capybara-screenshot
   capybara-select2
+  chronic
   coffee-rails (~> 4.2)
   coveralls (~> 0.8.12)
   daemons (~> 1.1.9)

--- a/lib/tasks/chattermill_reemit_events.rake
+++ b/lib/tasks/chattermill_reemit_events.rake
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'chronic'
+
+namespace :chattermill do
+  desc 'Re-emit source events for ChattermillResponseAgent. Use FROM and TO vars to indicate time range, e.g. FROM="2 hours ago" TO="10 minutes ago"'
+  task reemit_failed_events: :environment do
+    raise 'Please specify FROM and TO params.' if ENV['FROM'].blank? || ENV['TO'].blank?
+
+    from = Chronic.parse(ENV['FROM'])
+    raise 'Invalid FROM param' if from.nil?
+
+    to = Chronic.parse(ENV['TO'])
+    raise 'Invalid TO param' if to.nil?
+
+    statuses = ['%502 Bad Gateway%', '%504 Gateway Time-out%']
+
+    statuses.each do |status|
+      events = Event.joins(:agent)
+                    .where(created_at: (from..to))
+                    .where("payload LIKE ?", status)
+                    .where('agents.type': 'Agents::ChattermillResponseAgent')
+
+      source_events = events.map { |e| e.payload['source_event'] }.compact
+
+      if source_events.empty?
+        puts "No events to re-emit for '#{status}' errors"
+      else
+        puts "Re-emiting #{source_events.count} #{'event'.pluralize(source_events.count)} for '#{status}' errors"
+        Event.find(source_events).each(&:reemit!)
+      end
+    end
+
+    puts 'Done!'
+  end
+end


### PR DESCRIPTION
This rake task re-emit source events of failed events from Chattermill agent.
If there are some issues with our API, usually we get this response statuses:

* 502 Bad Gateway
* 504 Gateway Time-out

This rake task search for events with those errors and uses a time range.

Example:
`rake chattermill:reemit_failed_events FROM="2 hours ago" TO="30 minutes ago"`

`FROM` and `TO` params are required and accept any date/time expression that [chronic gem](https://github.com/mojombo/chronic) could parse.