### PR TITLE
Track all Sidekiq failures.

### DIFF
--- a/config/initializers/01_background_job_processor.rb
+++ b/config/initializers/01_background_job_processor.rb
@@ -36,7 +36,7 @@ elsif Rails.configuration.active_job.queue_adapter == :sidekiq
   Sidekiq.configure_server do |config|
     config.redis = { url: ENV['REDIS_URL'].presence || 'redis://localhost:6379/1' }
     config.failures_max_count = (ENV['FAILED_JOBS_TO_KEEP'].presence || 100).to_i
-    config.failures_default_mode = :exhausted
+    config.failures_default_mode = :all
   end
 
   Sidekiq.configure_client do |config|


### PR DESCRIPTION
What title says.

Also, just for information, we can control how many failed jobs we want to keep with `FAILED_JOBS_TO_KEEP` ENV variable, 100 by default.

### Screenshot

<img width="1329" alt="screen shot 2017-09-29 at 7 36 02 am" src="https://user-images.githubusercontent.com/75487/31014651-fd7d89b0-a4e9-11e7-9daf-347c0f12d035.png">