### PR TITLE
Add batch post  on Chattermill Response Agent

### DIFF
--- a/spec/models/agents/chattermill_response_agent_spec.rb
+++ b/spec/models/agents/chattermill_response_agent_spec.rb
@@ -294,6 +294,7 @@ describe Agents::ChattermillResponseAgent do
 
     context 'when send_batch_events is true' do
       before do
+        stub(ENV).[]('SLACK_WEBHOOK_URL') { 'http://slack.webhook/abc' }
         stub.any_instance_of(Slack::Notifier).ping { true }
 
         @valid_options.merge!('send_batch_events' => 'true', 'emit_events' => 'true')
@@ -374,7 +375,6 @@ describe Agents::ChattermillResponseAgent do
         expect(@checker.events.second.payload["body"]).to eq("error")
         expect(@checker.events.last.payload["body"]).to eq("error")
         expect(@checker.memory['events'].length).to eq(0)
-
       end
     end
   end
@@ -449,7 +449,7 @@ describe Agents::ChattermillResponseAgent do
 
     context 'when send_batch_events is true' do
       before do
-        @valid_options.merge!('send_batch_events' => 'true', 'max_events_on_buffer' => 2)
+        @valid_options.merge!('emit_events' => 'true', 'send_batch_events' => 'true', 'max_events_on_buffer' => 2)
 
         @checker = Agents::ChattermillResponseAgent.new({ name: "othername",
                                                           options: @valid_options })

--- a/spec/models/agents/chattermill_response_agent_spec.rb
+++ b/spec/models/agents/chattermill_response_agent_spec.rb
@@ -22,7 +22,7 @@ describe Agents::ChattermillResponseAgent do
       'user_meta' => user_meta.to_json,
       'extra_fields' => '{}',
       'send_batch_events' => 'false',
-      'max_events_on_buffer' => 2
+      'max_events_on_buffer' => 3
     }
     @valid_params = {
       name: "somename",
@@ -113,11 +113,20 @@ describe Agents::ChattermillResponseAgent do
 
       context 'when memory is not empty' do
         before do
-          @checker.memory['events'] = [@event.id]
+          other_event = Event.new
+          other_event.agent = agents(:jane_weather_agent)
+          other_event.payload = {
+            'somekey' => 'somevalue',
+            'data' => {
+              'comment' => 'Test Comment 2'
+            }
+          }
+          @checker.memory['events'] = [@event.id, other_event.id]
         end
 
         it "makes POST requests" do
           expect(@checker).to be_valid
+          expect(@checker.memory['events'].length).to eq(2)
           @checker.check
           expect(@requests).to eq(1)
           expect(@sent_requests[:post].length).to eq(1)
@@ -126,7 +135,7 @@ describe Agents::ChattermillResponseAgent do
         it "uses the correct URI" do
           @checker.check
           uri = @sent_requests[:post].first.uri.to_s
-          expect(uri).to eq("http://localhost:3000/webhooks/responses/list")
+          expect(uri).to eq("http://localhost:3000/webhooks/responses/bulk")
         end
 
         it "generates the authorization header" do
@@ -142,6 +151,7 @@ describe Agents::ChattermillResponseAgent do
         end
 
         it 'clean memory' do
+          expect(@checker.memory['events'].length).to eq(2)
           @checker.check
           expect(@checker.memory['events']).to be_empty
         end
@@ -150,207 +160,317 @@ describe Agents::ChattermillResponseAgent do
   end
 
   describe "#receive" do
-    it "can handle events with id" do
-      @checker.options['id'] = '123'
-      @checker.check
+    context 'when send_batch_events is false' do
+      it "can handle events with id" do
+        @checker.options['id'] = '123'
+        @checker.check
 
-      expect(@sent_requests[:patch].length).to eq(1)
-      uri = @sent_requests[:patch].first.uri.to_s
-      expect(uri).to eq("http://localhost:3000/webhooks/responses/123")
-    end
+        expect(@sent_requests[:patch].length).to eq(1)
+        uri = @sent_requests[:patch].first.uri.to_s
+        expect(uri).to eq("http://localhost:3000/webhooks/responses/123")
+      end
 
-    it "can handle multiple events" do
-      event1 = Event.new
-      event1.agent = agents(:bob_weather_agent)
-      event1.payload = {
-        'xyz' => 'value1',
-        'data' => {
-          'segment' => 'My Segment'
+      it "can handle multiple events" do
+        event1 = Event.new
+        event1.agent = agents(:bob_weather_agent)
+        event1.payload = {
+          'xyz' => 'value1',
+          'data' => {
+            'segment' => 'My Segment'
+          }
         }
-      }
 
-      expect {
-        @checker.receive([@event, event1])
-      }.to change { @sent_requests[:post].length }.by(2)
+        expect {
+          @checker.receive([@event, event1])
+        }.to change { @sent_requests[:post].length }.by(2)
 
-      expected = {
-        'comment' => 'Test Comment',
-        'segments' => { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => '' } },
-        'user_meta' => user_meta
-      }
-      expect(@sent_requests[:post][0].data).to eq(expected)
+        expected = {
+          'comment' => 'Test Comment',
+          'segments' => { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => '' } },
+          'user_meta' => user_meta
+        }
+        expect(@sent_requests[:post][0].data).to eq(expected)
 
-      expected = {
-        'segments' => { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => 'My Segment' } },
-        'user_meta' => user_meta
-      }
-      expect(@sent_requests[:post][1].data).to eq(expected)
+        expected = {
+          'segments' => { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => 'My Segment' } },
+          'user_meta' => user_meta
+        }
+        expect(@sent_requests[:post][1].data).to eq(expected)
+      end
+
+      describe "emitting events" do
+        context "when emit_events is not set to true" do
+          it "does not emit events" do
+            expect {
+              @checker.receive([@event])
+            }.not_to change { @checker.events.count }
+          end
+        end
+
+        context "when emit_events is set to true" do
+          before do
+            @checker.options['emit_events'] = 'true'
+          end
+
+          it "emits the response status" do
+            expect {
+              @checker.receive([@event])
+            }.to change { @checker.events.count }.by(1)
+            expect(@checker.events.last.payload['status']).to eq 201
+          end
+
+          it "emits the body" do
+            @checker.receive([@event])
+            expect(@checker.events.last.payload['body']).to eq '{}'
+          end
+
+          it "emits the response headers capitalized by default" do
+            @checker.receive([@event])
+            expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'application/json' })
+          end
+
+          it "emits the source event" do
+            @checker.receive([@event])
+            expect(@checker.events.last.payload['source_event']).to eq @event.id
+          end
+        end
+
+        describe "whith valid kind and score" do
+          before do
+            options = @valid_options.merge(
+              'score' => '{{ data.score }}',
+              'kind' => 'csat',
+              'emit_events' => true
+            )
+
+            @checker = Agents::ChattermillResponseAgent.create(
+              name: 'valid',
+              options: options,
+              user: users(:jane)
+            )
+          end
+
+          it "emits event" do
+            @event.payload['data']['score'] = '10'
+
+            expect {
+              @checker.receive([@event])
+            }.to change { @checker.events.count }.by(1)
+          end
+        end
+
+        describe "when payload validation fails" do
+          before do
+            options = @valid_options.merge(
+              'score' => '{{ data.score }}',
+              'kind' => 'nps',
+              'emit_events' => true
+            )
+
+            @checker = Agents::ChattermillResponseAgent.create(
+              name: 'invalid',
+              options: options,
+              user: users(:jane)
+            )
+          end
+
+          it "doesn't emit events" do
+            @event.payload['data']['score'] = ''
+
+            expect {
+              @checker.receive([@event])
+            }.not_to change { @checker.events.count }
+          end
+
+          it "logs a message with validation error" do
+            @event.payload['data']['score'] = ''
+            @event.save
+
+            expect {
+              @checker.receive([@event])
+            }.to change { @checker.logs.count }.by(1)
+
+            error = JSON.parse(@checker.logs.last.message)
+            expected = { "score" => ["can't be blank", "is not a number"], "source_event" => @event.id }
+            expect(error).to eq(expected)
+          end
+        end
+      end
     end
 
-    describe "emitting events" do
-      context "when emit_events is not set to true" do
-        it "does not emit events" do
-          expect {
-            @checker.receive([@event])
-          }.not_to change { @checker.events.count }
-        end
+    context 'when send_batch_events is true' do
+      before do
+        @valid_options.merge!('send_batch_events' => 'true')
+
+        @checker = Agents::ChattermillResponseAgent.new({ name: "othername",
+                                                          options: @valid_options })
+        @checker.user = users(:jane)
+        @checker.save!
       end
 
-      context "when emit_events is set to true" do
-        before do
-          @checker.options['emit_events'] = 'true'
-        end
-
-        it "emits the response status" do
-          expect {
-            @checker.receive([@event])
-          }.to change { @checker.events.count }.by(1)
-          expect(@checker.events.last.payload['status']).to eq 201
-        end
-
-        it "emits the body" do
+      it "save events in buffer" do
+        expect {
           @checker.receive([@event])
-          expect(@checker.events.last.payload['body']).to eq '{}'
-        end
+        }.to change { @sent_requests[:post].length }.by(0)
 
-        it "emits the response headers capitalized by default" do
-          @checker.receive([@event])
-          expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'application/json' })
-        end
-
-        it "emits the source event" do
-          @checker.receive([@event])
-          expect(@checker.events.last.payload['source_event']).to eq @event.id
-        end
+        expect(@checker.memory['events'].length).to eq(1)
+        expect(@checker.memory['events']).to eq([@event.id])
       end
 
-      describe "whith valid kind and score" do
-        before do
-          options = @valid_options.merge(
-            'score' => '{{ data.score }}',
-            'kind' => 'csat',
-            'emit_events' => true
-          )
+      it "can handle multiple events" do
+        event1 = Event.new
+        event1.agent = agents(:bob_weather_agent)
+        event1.payload = {
+          'xyz' => 'value1',
+          'data' => {
+            'segment' => 'My Segment'
+          }
+        }
 
-          @checker = Agents::ChattermillResponseAgent.create(
-            name: 'valid',
-            options: options,
-            user: users(:jane)
-          )
-        end
+        expect {
+          @checker.receive([@event, event1])
+        }.to change { @sent_requests[:post].length }.by(0)
 
-        it "emits event" do
-          @event.payload['data']['score'] = '10'
-
-          expect {
-            @checker.receive([@event])
-          }.to change { @checker.events.count }.by(1)
-        end
+        expect(@checker.memory['events'].length).to eq(2)
       end
 
-      describe "when payload validation fails" do
-        before do
-          options = @valid_options.merge(
-            'score' => '{{ data.score }}',
-            'kind' => 'nps',
-            'emit_events' => true
-          )
+      it "emit events when max events in buffer is reached" do
+        event1 = Event.new
+        event1.agent = agents(:bob_weather_agent)
+        event1.payload = {
+          'xyz' => 'value1',
+          'data' => {
+            'segment' => 'My Segment'
+          }
+        }
+        event2 = Event.new
+        event2.agent = agents(:bob_weather_agent)
+        event2.payload = {
+          'abc' => 'value1',
+          'data' => {
+            'comment' => 'Hello'
+          }
+        }
 
-          @checker = Agents::ChattermillResponseAgent.create(
-            name: 'invalid',
-            options: options,
-            user: users(:jane)
-          )
-        end
+        @checker.receive([@event, event1])
 
-        it "doesn't emit events" do
-          @event.payload['data']['score'] = ''
+        expect(@checker.memory['events'].length).to eq(2)
+        expect {
+          @checker.receive([event2])
+        }.to change { @sent_requests[:post].length }.by(1)
 
-          expect {
-            @checker.receive([@event])
-          }.not_to change { @checker.events.count }
-        end
-
-        it "logs a message with validation error" do
-          @event.payload['data']['score'] = ''
-          @event.save
-
-          expect {
-            @checker.receive([@event])
-          }.to change { @checker.logs.count }.by(1)
-
-          error = JSON.parse(@checker.logs.last.message)
-          expected = { "score" => ["can't be blank", "is not a number"], "source_event" => @event.id }
-          expect(error).to eq(expected)
-        end
+        expect(@checker.memory['events'].length).to eq(0)
       end
     end
   end
 
   describe "#check" do
-    it "sends data as a POST request" do
-      expect {
-        @checker.check
-      }.to change { @sent_requests[:post].length }.by(1)
+    context 'when send_batch_events is false' do
+      it "sends data as a POST request" do
+        expect {
+          @checker.check
+        }.to change { @sent_requests[:post].length }.by(1)
 
-      expected = {
-        'segments' => { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => '' } },
-        'user_meta' => user_meta
-      }
-      expect(@sent_requests[:post][0].data).to eq(expected)
-    end
+        expected = {
+          'segments' => { 'segment_id' => { 'type' => 'text', 'name' => 'Segment Id', 'value' => '' } },
+          'user_meta' => user_meta
+        }
+        expect(@sent_requests[:post][0].data).to eq(expected)
+      end
 
-    describe "emitting events" do
-      context "when emit_events is not set to true" do
-        it "does not emit events" do
-          expect {
+      describe "emitting events" do
+        context "when emit_events is not set to true" do
+          it "does not emit events" do
+            expect {
+              @checker.check
+            }.not_to change { @checker.events.count }
+          end
+        end
+
+        context "when emit_events is set to true" do
+          before do
+            @checker.options['emit_events'] = 'true'
+          end
+
+          it "emits the response status" do
+            expect {
+              @checker.check
+            }.to change { @checker.events.count }.by(1)
+            expect(@checker.events.last.payload['status']).to eq 201
+          end
+
+          it "emits the body" do
             @checker.check
-          }.not_to change { @checker.events.count }
+            expect(@checker.events.last.payload['body']).to eq '{}'
+          end
+
+          it "emits the response headers capitalized by default" do
+            @checker.check
+            expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'application/json' })
+          end
+
+          it "emits the source event" do
+            @checker.check
+            expect(@checker.events.last.payload['source_event']).to be_nil
+          end
         end
       end
 
-      context "when emit_events is set to true" do
+      describe "slack notification" do
         before do
-          @checker.options['emit_events'] = 'true'
+          stub(ENV).[]('CHATTERMILL_AUTH_TOKEN') { 'invalid' }
+          stub(ENV).[]('SLACK_WEBHOOK_URL') { 'http://slack.webhook/abc' }
+          stub(ENV).[]('SLACK_CHANNEL') { '#mychannel' }
         end
 
-        it "emits the response status" do
-          expect {
-            @checker.check
-          }.to change { @checker.events.count }.by(1)
-          expect(@checker.events.last.payload['status']).to eq 201
-        end
-
-        it "emits the body" do
+        it "sends a slack notification" do
+          slack = mock
+          mock(slack).ping('', hash_including({ icon_emoji: ':fire:', channel: '#mychannel' })) { true }
+          mock(Slack::Notifier).new('http://slack.webhook/abc', { username: 'Huginn' }) { slack }
           @checker.check
-          expect(@checker.events.last.payload['body']).to eq '{}'
-        end
-
-        it "emits the response headers capitalized by default" do
-          @checker.check
-          expect(@checker.events.last.payload['headers']).to eq({ 'Content-Type' => 'application/json' })
-        end
-
-        it "emits the source event" do
-          @checker.check
-          expect(@checker.events.last.payload['source_event']).to be_nil
         end
       end
     end
 
-    describe "slack notification" do
+    context 'when send_batch_events is true' do
       before do
-        stub(ENV).[]('CHATTERMILL_AUTH_TOKEN') { 'invalid' }
-        stub(ENV).[]('SLACK_WEBHOOK_URL') { 'http://slack.webhook/abc' }
-        stub(ENV).[]('SLACK_CHANNEL') { '#mychannel' }
+        @valid_options.merge!('send_batch_events' => 'true', 'max_events_on_buffer' => 2)
+
+        @checker = Agents::ChattermillResponseAgent.new({ name: "othername",
+                                                          options: @valid_options })
+        @checker.user = users(:jane)
+        @checker.save!
       end
 
-      it "sends a slack notification" do
-        slack = mock
-        mock(slack).ping('', hash_including({ icon_emoji: ':fire:', channel: '#mychannel' })) { true }
-        mock(Slack::Notifier).new('http://slack.webhook/abc', { username: 'Huginn' }) { slack }
-        @checker.check
+      it 'does not emit events if max events in buffer is not reached' do
+        @checker.receive([@event])
+
+        expect {
+          @checker.check
+        }.not_to change { @checker.events.count }
       end
+
+      it "sends data as a POST request" do
+        event1 = Event.new
+        event1.agent = agents(:bob_weather_agent)
+        event1.payload = {
+          'xyz' => 'value1',
+          'data' => {
+            'segment' => 'My Segment'
+          }
+        }
+        event1.save
+
+        @checker.memory['events'] = [@event.id, event1.id]
+
+        expect {
+          @checker.check
+        }.to change { @sent_requests[:post].length }.by(1)
+
+        expect(@checker.memory['events'].length).to eq(0)
+      end
+
+
     end
   end
 

--- a/spec/models/agents/chattermill_response_agent_spec.rb
+++ b/spec/models/agents/chattermill_response_agent_spec.rb
@@ -294,12 +294,25 @@ describe Agents::ChattermillResponseAgent do
 
     context 'when send_batch_events is true' do
       before do
-        @valid_options.merge!('send_batch_events' => 'true')
+        stub.any_instance_of(Slack::Notifier).ping { true }
+
+        @valid_options.merge!('send_batch_events' => 'true', 'emit_events' => 'true')
 
         @checker = Agents::ChattermillResponseAgent.new({ name: "othername",
                                                           options: @valid_options })
         @checker.user = users(:jane)
         @checker.save!
+
+        @event.save
+        @event1 = Event.new
+        @event1.agent = agents(:bob_weather_agent)
+        @event1.payload = {
+          'xyz' => 'value1',
+          'data' => {
+            'segment' => 'My Segment'
+          }
+        }
+        @event1.save
       end
 
       it "save events in buffer" do
@@ -312,31 +325,14 @@ describe Agents::ChattermillResponseAgent do
       end
 
       it "can handle multiple events" do
-        event1 = Event.new
-        event1.agent = agents(:bob_weather_agent)
-        event1.payload = {
-          'xyz' => 'value1',
-          'data' => {
-            'segment' => 'My Segment'
-          }
-        }
-
         expect {
-          @checker.receive([@event, event1])
+          @checker.receive([@event, @event1])
         }.to change { @sent_requests[:post].length }.by(0)
 
         expect(@checker.memory['events'].length).to eq(2)
       end
 
       it "emit events when max events in buffer is reached" do
-        event1 = Event.new
-        event1.agent = agents(:bob_weather_agent)
-        event1.payload = {
-          'xyz' => 'value1',
-          'data' => {
-            'segment' => 'My Segment'
-          }
-        }
         event2 = Event.new
         event2.agent = agents(:bob_weather_agent)
         event2.payload = {
@@ -345,13 +341,39 @@ describe Agents::ChattermillResponseAgent do
             'comment' => 'Hello'
           }
         }
+        event2.save
 
-        @checker.receive([@event, event1])
+        @checker.receive([@event, @event1])
 
         expect(@checker.memory['events'].length).to eq(2)
         expect {
           @checker.receive([event2])
         }.to change { @sent_requests[:post].length }.by(1)
+
+      end
+
+      it "emit events with error in case of status 500" do
+        stub_request(:post, "http://localhost:3000/webhooks/responses/bulk").to_return({ status: 500, body: 'error', headers: { 'Content-type' => 'application/json' } })
+
+        event2 = Event.new
+        event2.agent = agents(:bob_weather_agent)
+        event2.payload = {
+          'abc' => 'value1',
+          'data' => {
+            'comment' => 'Hello'
+          }
+        }
+        event2.save
+
+        expect(@checker.events.count).to eq(0)
+        @checker.receive([@event, @event1, event2])
+        @checker.save
+
+        expect(@checker.events.count).to eq(3)
+        expect(@checker.events.first.payload["body"]).to eq("error")
+        expect(@checker.events.second.payload["body"]).to eq("error")
+        expect(@checker.events.last.payload["body"]).to eq("error")
+        expect(@checker.memory['events'].length).to eq(0)
 
       end
     end


### PR DESCRIPTION
### New options

`send_batch_events`: `true` or `false`. False by default
`max_events_on_buffer`: maximum number of events that you'd like to hold in the buffer. 

When `send_batch_events` is true, the agent collects any events sent to it and sends them all later on reaching the number setted  in `max_events_on_buffer`.

When buffer reaches the maximum, all events will be emitted, this usually will happen on receive method, but it’s necessary to configure a schedule, just in case more events don't arrive, so events that are in buffer will be emited on check.

This agent create one event for each response returned from api. In case of a 500 status from api, will be create all events in memory with error and will be send a slack notification per event. 

https://github.com/chattermill/cm-backend/pull/587
