### PR TITLE
Change schedule by default to Chattermill Response Agent

### DIFF
--- a/app/models/agents/chattermill_response_agent.rb
+++ b/app/models/agents/chattermill_response_agent.rb
@@ -128,7 +128,7 @@ module Agents
         errors.add(:base, "if provided, send_batch_events must be true or false")
       end
 
-      if options.key?('send_batch_events') && boolify(options['send_batch_events']) && (schedule.blank? || schedule == 'never' )
+      if options.key?('send_batch_events') && boolify(options['send_batch_events']) && schedule == 'never'
         errors.add(:base, "Set a schedule value different than 'Never'")
       end
 


### PR DESCRIPTION
All agents inherits an `after_initialize :set_default_schedule` callback and each chattermill response agents that haven’t set a schedule and `send_batch_events` is `false`, that callback set schedule to the default schedule.
Schedule must be `never` by default. This PR solve that issue.