### PR TITLE
Add TrustPilot Huginn Agent with oAuth support

### DIFF
--- a/app/models/agents/trust_pilot_agent.rb
+++ b/app/models/agents/trust_pilot_agent.rb
@@ -37,15 +37,6 @@ module Agents
           "title": "Hello World …",
           "language": "en",
           "created_at": "2017-08-07T10:03:23Z",
-          "updated_at": "2017-08-07T10:03:23Z,
-          "company_reply": nil,
-          "is_verified": false,
-          "number_of_likes": 0,
-          "status": "active",
-          "report_data": nil,
-          "compliance_labels": [],
-          "consumer_name": "Jeffry Taraca",
-          "consumer_location": "Kirkeby, DK",
           "email": "jhon@email.com",
           "user_reference_id": "123"
         }

--- a/app/models/agents/trust_pilot_agent.rb
+++ b/app/models/agents/trust_pilot_agent.rb
@@ -8,7 +8,7 @@ module Agents
     UNIQUENESS_LOOK_BACK = 500
 
     can_dry_run!
-    no_bulk_receive!
+    cannot_receive_events!
 
     default_schedule 'every_1d'
 
@@ -67,8 +67,6 @@ module Agents
     end
 
     def validate_options
-      super
-
       %w[api_key api_secret].each do |key|
         errors.add(:base, "The '#{key}' option is required.") if options[key].blank?
       end
@@ -76,6 +74,12 @@ module Agents
       if options['business_units_ids'].blank?
         errors.add(:base, "The 'business_units_ids' option is required.")
       end
+
+      if options['expected_update_period_in_days'].blank?
+        errors.add(:base, "The 'expected_update_period_in_days' option is required.")
+      end
+
+      validate_web_request_options!
     end
 
     def check

--- a/app/models/agents/trust_pilot_agent.rb
+++ b/app/models/agents/trust_pilot_agent.rb
@@ -124,12 +124,7 @@ module Agents
     def store_payload!(review)
       case interpolated['mode'].presence
       when 'on_change'
-        review_id = review["id"]
-        if  old_events.find { |event| event.payload["id"] == review_id }
-          false
-        else
-          true
-        end
+        old_events.find { |event| event.payload["id"] == review["id"] }.blank?
       when 'all', 'merge', ''
         true
       else

--- a/app/models/agents/trust_pilot_agent.rb
+++ b/app/models/agents/trust_pilot_agent.rb
@@ -1,0 +1,117 @@
+module Agents
+  class TrustPilotAgent < Agent
+    include WebRequestConcern
+    include FormConfigurable
+
+    HTTP_METHOD = "get"
+    TRUSTPILOT_URL_BASE = "https://api.trustpilot.com/v1"
+
+    can_dry_run!
+    no_bulk_receive!
+
+    default_schedule 'every_1d'
+
+    description do
+      <<-MD
+        TrustPilot Agent fetches reviews from the TrustPilot API given client's access details and a list of Business Unit.
+
+        Options:
+
+          * `api_key` - TrustPilot Api Key.
+          * `api_secret` - TrustPilot Api Secret.
+          * `business_units_ids` - Specify the list of Business Units IDs for which Huginn will retrieve reviews.
+          * `expected_update_period_in_days` - Specify the period in days used to calculate if the agent is working.
+      MD
+    end
+
+    event_description <<-MD
+      Events look like this:
+        {
+          "id": "59883aebfba87f08a8274e07",
+          "stars": 5,
+          "text": "Hello World",
+          "title": "Hello World …",
+          "language": "en",
+          "created_at": "2017-08-07T10:03:23Z",
+          "updated_at": "2017-08-07T10:03:23Z,
+          "company_reply": nil,
+          "is_verified": false,
+          "number_of_likes": 0,
+          "status": "active",
+          "report_data": nil,
+          "compliance_labels": [],
+          "consumer_name": "Jeffry Taraca",
+          "consumer_location": "Kirkeby, DK"
+        }
+    MD
+
+    form_configurable :api_key
+    form_configurable :api_secret
+    form_configurable :business_units_ids
+    form_configurable :expected_update_period_in_days
+
+    def working?
+      event_created_within?(options['expected_update_period_in_days']) && !recent_error_logs?
+    end
+
+    def default_options
+      {
+        'api_key' => '{% credential TrustPilotApiKey %}',
+        'api_secret' => '{% credential TrustPilotApiSecret %}',
+        'expected_update_period_in_days' => '1'
+      }
+    end
+
+    def validate_options
+      super
+
+      %w[api_key api_secret].each do |key|
+        errors.add(:base, "The '#{key}' option is required.") if options[key].blank?
+      end
+
+      if options['business_units_ids'].blank?
+        errors.add(:base, "The 'business_units_ids' option is required.")
+      end
+    end
+
+    def check
+      reviews = business_units.map(&:parse_reviews).flatten
+      reviews.each do |review|
+        log "Storing new result for '#{name}': #{review.inspect}"
+        create_event payload: review
+      end
+    end
+
+    private
+
+    def headers(_ = {})
+      { "apikey" => "#{interpolated['api_key']}" }
+    end
+
+    def business_units
+      @business_units ||= business_units_ids.map do |bid|
+        business_unit = fetch_private_reviews(bid)
+        TrustPilotParser.new(business_unit)
+      end
+    end
+
+    def business_units_ids
+      @business_units_ids ||= interpolated['business_units_ids'].split(',').map(&:strip)
+    end
+
+    def fetch_private_reviews(business_unit_id)
+      # TODO: change to private review endpoint, need oauth
+      log "Fetching business unit: ##{business_unit_id} reviews"
+      url = "#{TRUSTPILOT_URL_BASE}/business-units/#{business_unit_id}/reviews"
+      fetch_resource(url)
+    end
+
+    def fetch_resource(uri)
+      response = faraday.get(uri)
+      return {} unless response.success?
+
+      JSON.parse(response.body)
+    end
+
+  end
+end

--- a/app/services/trust_pilot_parser.rb
+++ b/app/services/trust_pilot_parser.rb
@@ -6,62 +6,41 @@ class TrustPilotParser
   end
 
   def parse_reviews
-    reviews.map do |review|
-      ReviewParser.new(review).parse
+    reviews.map do |data|
+      Review.new(data).parse
     end
   end
 
-  class ReviewParser
-    ATTRIBUTES = %w[response_id score comment title language created_at updated_at company_reply
-                    is_verified number_of_likes status report_data compliance_labels
-                    consumer_name consumer_location email user_reference_id].freeze
-    attr_reader :data
+  class Review < OpenStruct
+    ATTRIBUTES = %w[response_id score comment title language created_at email user_reference_id].freeze
 
-    def initialize(data)
-      @data = OpenStruct.new(data)
-    end
-
-    def parse
-      ATTRIBUTES.inject({}) { |acc, key| acc.merge(key => extract_data(key)) }
-    end
-
-    private
-
-    def extract_data(key)
-      attr_name = key.camelize(:lower)
-      if data.respond_to?(attr_name)
-        data.send(attr_name)
-      else
-        send(key)
-      end
+    def initialize(hash = nil)
+      hash.deep_transform_keys!(&:underscore)
+      super
     end
 
     def response_id
-      data['id']
+      self['id']
     end
 
     def score
-      data['stars']
+      self['stars']
     end
 
     def comment
-      data['text']
+      self['text']
     end
 
     def email
-      data['referralEmail']
+      self['referral_email']
     end
 
     def user_reference_id
-      data['referenceId']
+      self['reference_id']
     end
 
-    def consumer_name
-      data.dig('consumer', 'displayName')
-    end
-
-    def consumer_location
-      data.dig('consumer', 'displayLocation')
+    def parse
+      ATTRIBUTES.inject({}) { |acc, key| acc.merge(key => send(key)) }
     end
   end
 end

--- a/app/services/trust_pilot_parser.rb
+++ b/app/services/trust_pilot_parser.rb
@@ -12,9 +12,9 @@ class TrustPilotParser
   end
 
   class ReviewParser
-    ATTRIBUTES = %w[id stars text title language created_at updated_at company_reply
+    ATTRIBUTES = %w[response_id score comment title language created_at updated_at company_reply
                     is_verified number_of_likes status report_data compliance_labels
-                    consumer_name consumer_location].freeze
+                    consumer_name consumer_location email user_reference_id].freeze
     attr_reader :data
 
     def initialize(data)
@@ -34,6 +34,26 @@ class TrustPilotParser
       else
         send(key)
       end
+    end
+
+    def response_id
+      data['id']
+    end
+
+    def score
+      data['stars']
+    end
+
+    def comment
+      data['text']
+    end
+
+    def email
+      data['referralEmail']
+    end
+
+    def user_reference_id
+      data['referenceId']
     end
 
     def consumer_name

--- a/app/services/trust_pilot_parser.rb
+++ b/app/services/trust_pilot_parser.rb
@@ -1,0 +1,47 @@
+class TrustPilotParser
+  attr_reader :reviews
+
+  def initialize(data)
+    @reviews = data['reviews'] || []
+  end
+
+  def parse_reviews
+    reviews.map do |review|
+      ReviewParser.new(review).parse
+    end
+  end
+
+  class ReviewParser
+    ATTRIBUTES = %w[id stars text title language created_at updated_at company_reply
+                    is_verified number_of_likes status report_data compliance_labels
+                    consumer_name consumer_location].freeze
+    attr_reader :data
+
+    def initialize(data)
+      @data = OpenStruct.new(data)
+    end
+
+    def parse
+      ATTRIBUTES.inject({}) { |acc, key| acc.merge(key => extract_data(key)) }
+    end
+
+    private
+
+    def extract_data(key)
+      attr_name = key.camelize(:lower)
+      if data.respond_to?(attr_name)
+        data.send(attr_name)
+      else
+        send(key)
+      end
+    end
+
+    def consumer_name
+      data.dig('consumer', 'displayName')
+    end
+
+    def consumer_location
+      data.dig('consumer', 'displayLocation')
+    end
+  end
+end

--- a/spec/data_fixtures/trustpilot_refresh_token.json
+++ b/spec/data_fixtures/trustpilot_refresh_token.json
@@ -1,0 +1,9 @@
+{
+  "access_token": "NOnI0OxB8S5fqbDZoYP17maEsYSg",
+  "refresh_token": "EEfgro79v00TIhKMA9uvVqFmlGM6zN9m",
+  "scope": "",
+  "refresh_token_issued_at": "1509474200158",
+  "expires_in": "359999",
+  "refresh_count": "1",
+  "status": "approved"
+}

--- a/spec/data_fixtures/trustpilot_reviews.json
+++ b/spec/data_fixtures/trustpilot_reviews.json
@@ -1,0 +1,235 @@
+{
+    "links": [
+        {
+            "href": "https://api.trustpilot.com/v1/business-units/468302bb00006400050000a5",
+            "method": "GET",
+            "rel": "business-units"
+        }
+    ],
+    "reviews": [
+        {
+            "links": [
+                {
+                    "href": "https://api.trustpilot.com/v1/reviews/59883aebfba87f08a8274e07",
+                    "method": "GET",
+                    "rel": "reviews"
+                },
+                {
+                    "href": "https://api.trustpilot.com/v1/reviews/59883aebfba87f08a8274e07/web-links",
+                    "method": "GET",
+                    "rel": "reviews-web-links"
+                },
+                {
+                    "href": "https://api.trustpilot.com/v1/resources/images/stars/1",
+                    "method": "GET",
+                    "rel": "resources-images-stars"
+                }
+            ],
+            "id": "59883aebfba87f08a8274e07",
+            "consumer": {
+                "links": [
+                    {
+                        "href": "https://api.trustpilot.com/v1/consumers/593fae8d0000ff000aa31267",
+                        "method": "GET",
+                        "rel": "consumers"
+                    },
+                    {
+                        "href": "https://user-images.trustpilot.com/593fae8d0000ff000aa31267/73x73.png",
+                        "method": "GET",
+                        "rel": "profile-image"
+                    }
+                ],
+                "id": "593fae8d0000ff000aa31267",
+                "displayName": "Jeffry Taraca",
+                "displayLocation": null,
+                "numberOfReviews": 1
+            },
+            "businessUnit": {
+                "links": [
+                    {
+                        "href": "https://api.trustpilot.com/v1/business-units/468302bb00006400050000a5",
+                        "method": "GET",
+                        "rel": "business-units"
+                    },
+                    {
+                        "href": "https://s3-eu-west-1.amazonaws.com/tpd/screenshots/468302bb00006400050000a5/57x43.png",
+                        "method": "GET",
+                        "rel": "profile-image-small"
+                    },
+                    {
+                        "href": "https://s3-eu-west-1.amazonaws.com/tpd/screenshots/468302bb00006400050000a5/118x89.png",
+                        "method": "GET",
+                        "rel": "profile-image-medium"
+                    },
+                    {
+                        "href": "https://s3-eu-west-1.amazonaws.com/tpd/screenshots/468302bb00006400050000a5/198x149.png",
+                        "method": "GET",
+                        "rel": "profile-image-large"
+                    }
+                ],
+                "id": "468302bb00006400050000a5",
+                "identifyingName": "www.actebis.dk",
+                "displayName": "Actebis"
+            },
+            "stars": 1,
+            "title": "Som ny erhvervsdrivende har jeg forsøgt …",
+            "text": "Som ny erhvervsdrivende har jeg forsøgt at oprette login til Actebis/Also.. Det gik da også fint, og søde mennesker indtil for ca 3 uger siden, da jeg fik login problemer.. Siden da har jeg sendt dem 6 E-mails og ringet 3 gange, men uden at modtage nogen form for respons eller hjælp. Det er utilgiveligt at man bare bliver efterladt hængende uden svar.\n\nHvis det er fordi de ikke mener man er vigtig nok, så få lidt mellem benene og skriv det i stedet, det værste er manglen på respons.\n\nKan absolut ikke anbefales... Det findes heldigvis mange andre leverandører som er både pålidelige og som har bare en lille snert af kundevenlig service.",
+            "language": "da",
+            "createdAt": "2017-08-07T10:03:23Z",
+            "updatedAt": null,
+            "companyReply": null,
+            "isVerified": false,
+            "numberOfLikes": 0,
+            "status": "active",
+            "reportData": null,
+            "complianceLabels": [],
+            "countsTowardsTrustScore": true
+        },
+        {
+            "links": [
+                {
+                    "href": "https://api.trustpilot.com/v1/reviews/56b85a2b0000ff000938b8bd",
+                    "method": "GET",
+                    "rel": "reviews"
+                },
+                {
+                    "href": "https://api.trustpilot.com/v1/reviews/56b85a2b0000ff000938b8bd/web-links",
+                    "method": "GET",
+                    "rel": "reviews-web-links"
+                },
+                {
+                    "href": "https://api.trustpilot.com/v1/resources/images/stars/1",
+                    "method": "GET",
+                    "rel": "resources-images-stars"
+                }
+            ],
+            "id": "56b85a2b0000ff000938b8bd",
+            "consumer": {
+                "links": [
+                    {
+                        "href": "https://api.trustpilot.com/v1/consumers/50c5c2f20000640001299ba2",
+                        "method": "GET",
+                        "rel": "consumers"
+                    }
+                ],
+                "id": "50c5c2f20000640001299ba2",
+                "displayName": "Michael",
+                "displayLocation": null,
+                "numberOfReviews": 14
+            },
+            "businessUnit": {
+                "links": [
+                    {
+                        "href": "https://api.trustpilot.com/v1/business-units/468302bb00006400050000a5",
+                        "method": "GET",
+                        "rel": "business-units"
+                    },
+                    {
+                        "href": "https://s3-eu-west-1.amazonaws.com/tpd/screenshots/468302bb00006400050000a5/57x43.png",
+                        "method": "GET",
+                        "rel": "profile-image-small"
+                    },
+                    {
+                        "href": "https://s3-eu-west-1.amazonaws.com/tpd/screenshots/468302bb00006400050000a5/118x89.png",
+                        "method": "GET",
+                        "rel": "profile-image-medium"
+                    },
+                    {
+                        "href": "https://s3-eu-west-1.amazonaws.com/tpd/screenshots/468302bb00006400050000a5/198x149.png",
+                        "method": "GET",
+                        "rel": "profile-image-large"
+                    }
+                ],
+                "id": "468302bb00006400050000a5",
+                "identifyingName": "www.actebis.dk",
+                "displayName": "Actebis"
+            },
+            "stars": 1,
+            "title": "Slet ingen respons",
+            "text": "Som ny erhvervsdrivende har jeg forsøgt at oprette login til Actebis/Also.. Det gik da også fint, og søde mennesker indtil for ca 3 uger siden, da jeg fik login problemer.. Siden da har jeg sendt dem 6 E-mails og ringet 3 gange, men uden at modtage nogen form for respons eller hjælp. Det er utilgiveligt at man bare bliver efterladt hængende uden svar. \r\n\r\nHvis det er fordi de ikke mener man er vigtig nok, så få lidt mellem benene og skriv det i stedet, det værste er manglen på respons. \r\n\r\nKan absolut ikke anbefales... Det findes heldigvis mange andre leverandører som er både pålidelige og som har bare en lille snert af kundevenlig service.",
+            "language": "da",
+            "createdAt": "2016-02-08T09:04:43Z",
+            "updatedAt": null,
+            "companyReply": null,
+            "isVerified": false,
+            "numberOfLikes": 1,
+            "status": "active",
+            "reportData": null,
+            "complianceLabels": [],
+            "countsTowardsTrustScore": true
+        },
+        {
+            "links": [
+                {
+                    "href": "https://api.trustpilot.com/v1/reviews/504e1c59000064000227282c",
+                    "method": "GET",
+                    "rel": "reviews"
+                },
+                {
+                    "href": "https://api.trustpilot.com/v1/reviews/504e1c59000064000227282c/web-links",
+                    "method": "GET",
+                    "rel": "reviews-web-links"
+                },
+                {
+                    "href": "https://api.trustpilot.com/v1/resources/images/stars/4",
+                    "method": "GET",
+                    "rel": "resources-images-stars"
+                }
+            ],
+            "id": "504e1c59000064000227282c",
+            "consumer": {
+                "links": [
+                    {
+                        "href": "https://api.trustpilot.com/v1/consumers/4d9ae768000064000107a997",
+                        "method": "GET",
+                        "rel": "consumers"
+                    }
+                ],
+                "id": "4d9ae768000064000107a997",
+                "displayName": "T.T",
+                "displayLocation": "kbh, DK",
+                "numberOfReviews": 4
+            },
+            "businessUnit": {
+                "links": [
+                    {
+                        "href": "https://api.trustpilot.com/v1/business-units/468302bb00006400050000a5",
+                        "method": "GET",
+                        "rel": "business-units"
+                    },
+                    {
+                        "href": "https://s3-eu-west-1.amazonaws.com/tpd/screenshots/468302bb00006400050000a5/57x43.png",
+                        "method": "GET",
+                        "rel": "profile-image-small"
+                    },
+                    {
+                        "href": "https://s3-eu-west-1.amazonaws.com/tpd/screenshots/468302bb00006400050000a5/118x89.png",
+                        "method": "GET",
+                        "rel": "profile-image-medium"
+                    },
+                    {
+                        "href": "https://s3-eu-west-1.amazonaws.com/tpd/screenshots/468302bb00006400050000a5/198x149.png",
+                        "method": "GET",
+                        "rel": "profile-image-large"
+                    }
+                ],
+                "id": "468302bb00006400050000a5",
+                "identifyingName": "www.actebis.dk",
+                "displayName": "Actebis"
+            },
+            "stars": 4,
+            "title": "Godt",
+            "text": "De har styr på det, fungerer godt.",
+            "language": "da",
+            "createdAt": "2012-09-10T16:59:05Z",
+            "updatedAt": null,
+            "companyReply": null,
+            "isVerified": false,
+            "numberOfLikes": 0,
+            "status": "active",
+            "reportData": null,
+            "complianceLabels": [],
+            "countsTowardsTrustScore": true
+        }
+    ]
+}

--- a/spec/data_fixtures/trustpilot_reviews.json
+++ b/spec/data_fixtures/trustpilot_reviews.json
@@ -83,7 +83,9 @@
             "status": "active",
             "reportData": null,
             "complianceLabels": [],
-            "countsTowardsTrustScore": true
+            "countsTowardsTrustScore": true,
+            "referralEmail": "jhon@email.com",
+            "referenceId": "123"
         },
         {
             "links": [
@@ -156,7 +158,9 @@
             "status": "active",
             "reportData": null,
             "complianceLabels": [],
-            "countsTowardsTrustScore": true
+            "countsTowardsTrustScore": true,
+            "referralEmail": "jhon@email.com",
+            "referenceId": "123"
         },
         {
             "links": [
@@ -229,7 +233,9 @@
             "status": "active",
             "reportData": null,
             "complianceLabels": [],
-            "countsTowardsTrustScore": true
+            "countsTowardsTrustScore": true,
+            "referralEmail": "jhon@email.com",
+            "referenceId": "123"
         }
     ]
 }

--- a/spec/models/agents/trust_pilot_agent_spec.rb
+++ b/spec/models/agents/trust_pilot_agent_spec.rb
@@ -115,15 +115,6 @@ describe Agents::TrustPilotAgent do
                    "title": "Godt",
                    "language": "da",
                    "created_at": "2012-09-10T16:59:05Z",
-                   "updated_at": nil,
-                   "company_reply": nil,
-                   "is_verified": false,
-                   "number_of_likes": 0,
-                   "status": "active",
-                   "report_data": nil,
-                   "compliance_labels": [],
-                   "consumer_name": "T.T",
-                   "consumer_location": "kbh, DK",
                    "email": "jhon@email.com",
                    "user_reference_id": "123" }.stringify_keys!
       @checker.check

--- a/spec/models/agents/trust_pilot_agent_spec.rb
+++ b/spec/models/agents/trust_pilot_agent_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+describe Agents::TrustPilotAgent do
+  before do
+    @valid_params = {
+      name: "somename",
+      options: {
+        api_key: 'some_api_key',
+        api_secret: 'some_api_secret',
+        expected_update_period_in_days: 1,
+        business_units_ids: '468302bb00006400050000a5',
+        mode: 'on_change'
+      }
+    }
+
+    @checker = Agents::TrustPilotAgent.new(@valid_params)
+    @checker.user = users(:jane)
+    @checker.save!
+
+    @event = Event.new
+    @event.agent = @checker
+    @event.payload = {
+      message: "hey what are you doing",
+      xyz: "do tell more"
+    }
+  end
+
+  it 'renders the description markdown without errors' do
+    expect { @checker.description }.not_to raise_error
+  end
+
+  describe "#working?" do
+    it "checks if events have been created within expected update period" do
+      expect(@checker).not_to be_working
+      @event.save!
+      expect(@checker.reload).to be_working
+      two_days_from_now = 2.days.from_now
+      stub(Time).now { two_days_from_now }
+      expect(@checker.reload).not_to be_working
+    end
+  end
+
+  describe "validation" do
+    before do
+      expect(@checker).to be_valid
+    end
+
+    it "should validate presence of api key" do
+      @checker.options[:api_key] = nil
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate presence of api secret" do
+      @checker.options[:api_secret] = nil
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate presence of business_units_ids" do
+      @checker.options[:business_units_ids] = nil
+      expect(@checker).not_to be_valid
+    end
+
+    it "should validate presence of expected_update_period_in_days key" do
+      @checker.options[:expected_update_period_in_days] = nil
+      expect(@checker).not_to be_valid
+    end
+  end
+
+  describe "#check" do
+    before(:each) do
+      stub_request(:get, /reviews$/).to_return(
+        :body => File.read(Rails.root.join("spec/data_fixtures/trustpilot_reviews.json")),
+        :status => 200,
+        :headers => {"Content-Type" => "text/json"}
+      )
+    end
+
+    it "emits events per each review" do
+      expect { @checker.check }.to change { Event.count }.by(3)
+    end
+
+    it "emits review data" do
+      expected = { "id": "504e1c59000064000227282c",
+                   "stars": 4,
+                   "text": "De har styr på det, fungerer godt.",
+                   "title": "Godt",
+                   "language": "da",
+                   "created_at": "2012-09-10T16:59:05Z",
+                   "updated_at": nil,
+                   "company_reply": nil,
+                   "is_verified": false,
+                   "number_of_likes": 0,
+                   "status": "active",
+                   "report_data": nil,
+                   "compliance_labels": [],
+                   "consumer_name": "T.T",
+                   "consumer_location": "kbh, DK"
+                 }.stringify_keys!
+      @checker.check
+      expect(@checker.events.count).to eq(3)
+      expect(@checker.events.first.payload).to eq(expected)
+    end
+
+    it "does not duplicate reviews" do
+      expect(@checker.events.count).to eq(0)
+      @checker.check
+      expect(@checker.events.count).to eq(3)
+      other_checker = Agents::TrustPilotAgent.first
+      other_checker.check
+      expect(other_checker.events.count).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
TrustPilot Agent fetches reviews from the TrustPilot API private reviews endpoint, given client's access details and a list of Business Units.

The agent needs initial AccessToken and RefreshToken; every time check is called the agent verifies the access token expiration date, if it's expired a request will be made to the refresh token endpoint and they will be updated.

Events look like this:
```
        {
          "response_id": "59883aebfba87f08a8274e07",
          "score": 5,
          "comment": "Hello World",
          "title": "Hello World …",
          "language": "en",
          "created_at": "2017-08-07T10:03:23Z",
          "email": "jhon@email.com",
          "user_reference_id": "123"
        }
```

### Screenshots
![agent_form](https://user-images.githubusercontent.com/922866/32290722-4f2be4f0-bf11-11e7-9cad-faaaba3a5511.png)
![agent_options](https://user-images.githubusercontent.com/922866/32290754-65f99470-bf11-11e7-9943-28a315b24917.png)

https://trello.com/c/qb6pH1lN/450-trustpilot-huginn-agent-with-oauth-support