### PR TITLE
Search for other comment fields in Usabilla Agent.

### DIFF
--- a/app/models/agents/usabilla_agent.rb
+++ b/app/models/agents/usabilla_agent.rb
@@ -261,7 +261,10 @@ module Agents
 
     def extract_comment(response)
       return response.comment if response.respond_to?(:comment)
-      response.data[:comment] if response.respond_to?(:data) && response.data.is_a?(Hash)
+
+      if response.respond_to?(:data) && response.data.is_a?(Hash)
+        response.data.find { |k, v| k.to_s.start_with?('comment') && v.present? }&.last
+      end
     end
 
     def extract_score(response)


### PR DESCRIPTION
Usabilla Agent now search for any field that contains the word `comment`, and use it as main `comment` field. Examples `comment_1` / `comment_promoter`, etc.

### Screeshot
<img width="865" alt="screen shot 2017-10-30 at 4 41 45 pm" src="https://user-images.githubusercontent.com/75487/32194815-d95fa0d4-bd91-11e7-8344-c9945d992287.png">