### PR TITLE
Fix SurveyMonkeyParser when data['pages'] is nil.

### DIFF
--- a/app/services/survey_monkey_parser.rb
+++ b/app/services/survey_monkey_parser.rb
@@ -38,7 +38,7 @@ class SurveyMonkeyParser
     attr_reader :data
 
     def questions
-      @questions ||= data['pages'].map { |page| page['questions'] }.flatten
+      @questions ||= (data['pages'] || []).map { |page| page['questions'] }.flatten
     end
   end
 


### PR DESCRIPTION
This should prevent: https://rollbar.com/chattermill/huginn/items/56/

I couldn't reproduce it though.