### PR TITLE
Add ability to hard-code score / comment question ids on the SurveyMonkey huginn agent

### DIFF
--- a/app/services/survey_monkey_parser.rb
+++ b/app/services/survey_monkey_parser.rb
@@ -33,6 +33,14 @@ class SurveyMonkeyParser
       questions.find { |q| q['id'] == id }
     end
 
+    def score_keys
+      @score_key ||= (data['score_question_ids'] || "text").split(',')
+    end
+
+    def comment_keys
+      @comment_key ||= (data['comment_question_ids'] || "text").split(',')
+    end
+
     private
 
     attr_reader :data
@@ -89,7 +97,9 @@ class SurveyMonkeyParser
     end
 
     def parsed_score_answer
-      score_options.find { |c| c['id'] == score_answer_given }['text'].gsub(/[^0-9]/, '').to_i
+      choice = score_options.find { |c| c['id'] == score_answer_given }
+      key = survey.score_keys.find {|k| choice[k] }
+      choice[key].to_s.gsub(/[^0-9]/, '').to_i
     end
 
     def comment_question
@@ -101,7 +111,8 @@ class SurveyMonkeyParser
     end
 
     def parsed_comment_answer
-      comment_answer_given['text']
+      key = survey.comment_keys.find {|k| comment_answer_given[k] }
+      comment_answer_given[key]
     end
   end
 end


### PR DESCRIPTION
### New Options
          * `guess_mode` - Let the agent try to figure out the score question and the comment question automatically.
          * `score_question_ids` - Hard-code the comma separated list of ids of the score questions (agent will pick the first one present) if `guess_mode` is off
          * `comment_question_ids` - Hard-code he comma separated list of ids of the comment questions (agent will pick the first one present) if `guess_mode` is off


https://trello.com/c/VqLfqvJm/452-add-ability-to-hard-code-score-comment-question-ids-on-the-surveymonkey-huginn-agent
