### PR TITLE
Fix hardcode score/comment question ids

### DIFF
--- a/app/models/agents/survey_monkey_agent.rb
+++ b/app/models/agents/survey_monkey_agent.rb
@@ -52,7 +52,7 @@ module Agents
         'api_token' => '{% credential SurveyMonkeyToken %}',
         'expected_update_period_in_days' => '2',
         'mode' => 'on_change',
-        'guess_mode' => true,
+        'guess_mode' => 'true'
       }
     end
 


### PR DESCRIPTION
When guess_mode is off, the first question that matches the ids specified in `score_question_ids` or `comment_question_ids` will be taken, the one with the most left has the highest priority. if no question matches, it will be returned `null` for comment and `0` for score.