### PR TITLE
Fix slack description for chattermill response agent errors

### DIFF
--- a/app/models/agents/chattermill_response_agent.rb
+++ b/app/models/agents/chattermill_response_agent.rb
@@ -342,7 +342,7 @@ module Agents
     def send_slack_notification(response, event)
       link = "<https://huginn.chattermill.xyz/agents/#{event.agent_id}/events|Details>"
       source_event_link = "<https://huginn.chattermill.xyz/events/#{event.id}|Source event>"
-      parsed_body = JSON.parse(response.body) rescue ""
+      parsed_body = JSON.parse(response.body) rescue response.body
 
       description = "```#{parsed_body}```\n#{source_event_link} | #{link}"
 


### PR DESCRIPTION
With this fix, slack errors messages will show them, like this:

![captura de pantalla 2017-11-13 a las 9 15 40 a m](https://user-images.githubusercontent.com/922866/32727624-82f7e914-c853-11e7-9c10-ea3aca0b460b.png)
 