### PR TITLE
Fix Gateway timeout

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -6,6 +6,6 @@ class Link < ActiveRecord::Base
   before_create :store_event_id_at_creation
 
   def store_event_id_at_creation
-    self.event_id_at_creation = source.events.limit(1).reorder("id desc").pluck(:id).first || 0
+    self.event_id_at_creation = source.events.limit(1).reorder("id desc NULLS LAST").pluck(:id).first || 0
   end
 end

--- a/db/migrate/20171116221108_add_index_to_events.rb
+++ b/db/migrate/20171116221108_add_index_to_events.rb
@@ -1,0 +1,5 @@
+class AddIndexToEvents < ActiveRecord::Migration[5.1]
+  def change
+    add_index(:events, :id, order: {id: :desc})
+  end
+end

--- a/db/migrate/20171116221108_add_index_to_events.rb
+++ b/db/migrate/20171116221108_add_index_to_events.rb
@@ -1,5 +1,6 @@
 class AddIndexToEvents < ActiveRecord::Migration[5.1]
   def change
     add_index(:events, :id, order: {id: :desc})
+    add_index(:events, :agent_id)
   end
 end


### PR DESCRIPTION
This error is because the next query  is taking long time (103 sec) and nginx has a 60s timeout:

```
EXPLAIN ANALYZE SELECT  "events"."id" FROM "events" WHERE "events"."agent_id" = 670 ORDER BY id desc LIMIT 1;
                                                                      QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..589.44 rows=1 width=4) (actual time=103203.089..103203.089 rows=0 loops=1)
   ->  Index Scan Backward using events_pkey on events  (cost=0.43..1238695.70 rows=2103 width=4) (actual time=103203.078..103203.078 rows=0 loops=1)
         Filter: (agent_id = 670)
         Rows Removed by Filter: 2630127
 Planning time: 8.543 ms
 Execution time: **103203.510** ms

```
After:

```
EXPLAIN ANALYZE SELECT  "events"."id" FROM "events" WHERE "events"."agent_id" = 670 ORDER BY id desc NULLS LAST LIMIT 1;
                                                                            QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=6863.45..6863.45 rows=1 width=4) (actual time=0.505..0.505 rows=0 loops=1)
   ->  Sort  (cost=6863.45..6868.71 rows=2103 width=4) (actual time=0.503..0.503 rows=0 loops=1)
         Sort Key: id DESC NULLS LAST
         Sort Method: quicksort  Memory: 25kB
         ->  Index Scan using index_events_on_agent_id_and_created_at on events  (cost=0.43..6852.93 rows=2103 width=4) (actual time=0.128..0.128 rows=0 loops=1)
               Index Cond: (agent_id = 670)
 Planning time: 2.695 ms
 Execution time: **0.630** ms
``` 