### PR TITLE
Special Uber typeform agent

### DIFF
--- a/app/models/agents/typeform_response_agent.rb
+++ b/app/models/agents/typeform_response_agent.rb
@@ -100,7 +100,7 @@ module Agents
             "country_id": "25",
             "tc": "2"
           },
-          "mappings": {
+          "mapped_variables": {
             "city_id": "London"
             "country_id": "UK",
           }


### PR DESCRIPTION
- [x]  Add hidden variables mapping functionality.
- [x] Add a bucketing functionality

To map any hidden variable value you must specify the hash object in the field mapping_object, e.g.:

Given hidden variables (json from Typeform):
```
{
    "token": "7479d0fd-5fbc-44a9-991b-f1ce4c3db221",
    "city_id": "458",
    "country_id": "25",
    "tc": "2",
    "score: "9"
  }
```

The mapping object should be (e.g):
```
{
  "city_id": {"458" => "New York", "27" => "Lima"},
  "country_id": {"25" => "US", "1" => "Peru"},
}
```

The bucketing object should be (e.g):
```
{
  "tc": {"0" => "BUCKET A", "1-3" => "BUCKET B", "3-10" => "BUCKET C", "10+" => "BUCKET D"}
}
```

The event return a new json attribute `mapped_variables`.
