### PR TITLE
Add total queue size metric to CloudWatch

### DIFF
--- a/lib/tasks/sidekiq_metrics.rake
+++ b/lib/tasks/sidekiq_metrics.rake
@@ -10,8 +10,12 @@ namespace :sidekiq do
         latency: { value: queue.latency.to_i, unit: 'Seconds' }
       }
     end
+
     total_size = queues.values.reduce(0) { |sum, e| sum + e[:size][:value] }
     summary = Hash["Total", { size: { value: total_size, unit: "Count" } }]
+
+    max_latency = queues.values.max_by { |m| m[:latency][:value] }[:latency]
+    summary["Max"] = { latency: max_latency }
 
     puts 'Sending metrics to CloudWatch'
     CloudwatchMetricCreator.new("Huginn/Sidekiq", "Queue Name", queues).create!

--- a/lib/tasks/sidekiq_metrics.rake
+++ b/lib/tasks/sidekiq_metrics.rake
@@ -10,9 +10,12 @@ namespace :sidekiq do
         latency: { value: queue.latency.to_i, unit: 'Seconds' }
       }
     end
+    total_size = queues.values.reduce(0) { |sum, e| sum + e[:size][:value] }
+    summary = Hash["Total", { size: { value: total_size, unit: "Count" } }]
 
     puts 'Sending metrics to CloudWatch'
     CloudwatchMetricCreator.new("Huginn/Sidekiq", "Queue Name", queues).create!
+    puts CloudwatchMetricCreator.new("Huginn/Sidekiq", "Summary", summary).create!
     puts 'Done!'
   end
 end

--- a/lib/tasks/sidekiq_metrics.rake
+++ b/lib/tasks/sidekiq_metrics.rake
@@ -15,7 +15,7 @@ namespace :sidekiq do
 
     puts 'Sending metrics to CloudWatch'
     CloudwatchMetricCreator.new("Huginn/Sidekiq", "Queue Name", queues).create!
-    puts CloudwatchMetricCreator.new("Huginn/Sidekiq", "Summary", summary).create!
+    CloudwatchMetricCreator.new("Huginn/Sidekiq", "Summary", summary).create!
     puts 'Done!'
   end
 end


### PR DESCRIPTION
It create a new `Summary` dimension with Total Queue Size metric.

```
{
  namespace: "Huginn/Sidekiq",
  metric_data: {
    metric_name: "Size",
    dimensions: [
      {
        name: "Summary",
        value: "Total"
      }
    ],
    value: 9999,
    unit: "Count",
    timestamp: timestamp
}
```