### PR TITLE
Ability to get scores for questions with multiple rows on SurveyMonkey agent

### DIFF
--- a/app/models/agents/survey_monkey_agent.rb
+++ b/app/models/agents/survey_monkey_agent.rb
@@ -149,13 +149,7 @@ module Agents
 
     def surveys
       @surveys ||= survey_ids.map do |survey_id|
-        survey = fetch_survey_details(survey_id)
-        survey['responses'] = fetch_survey_responses(survey_id)
-        if boolify(interpolated['guess_mode']) == false
-          survey['score_question_ids'] = interpolated['score_question_ids']
-          survey['comment_question_ids'] = interpolated['comment_question_ids']
-        end
-        survey['use_weights'] = boolify(interpolated['use_weights'])
+        survey = build_survey(survey_id)
         SurveyMonkeyParser.new(survey)
       end
     end
@@ -170,6 +164,17 @@ module Agents
 
     def per_page
       interpolated['per_page']
+    end
+
+    def build_survey(survey_id)
+      survey = fetch_survey_details(survey_id)
+      survey['responses'] = fetch_survey_responses(survey_id)
+      if boolify(interpolated['guess_mode']) == false
+        survey['score_question_ids'] = interpolated['score_question_ids']
+        survey['comment_question_ids'] = interpolated['comment_question_ids']
+      end
+      survey['use_weights'] = boolify(interpolated['use_weights'])
+      survey
     end
 
     def fetch_survey_responses(survey_id)

--- a/app/models/agents/survey_monkey_agent.rb
+++ b/app/models/agents/survey_monkey_agent.rb
@@ -183,7 +183,10 @@ module Agents
 
     def fetch_survey_monkey_resource(uri)
       response = faraday.get(uri)
-      return {} unless response.success?
+      unless response.success?
+        log "Failed #{response.status}: #{response.body}"
+        return {}
+      end
 
       JSON.parse(response.body)
     end

--- a/app/models/agents/survey_monkey_agent.rb
+++ b/app/models/agents/survey_monkey_agent.rb
@@ -54,7 +54,8 @@ module Agents
         'mode' => 'on_change',
         'page' => '1',
         'per_page' => '100',
-        'guess_mode' => 'true'
+        'guess_mode' => 'true',
+        'use_weights' => 'false'
       }
     end
 
@@ -70,6 +71,7 @@ module Agents
     form_configurable :survey_ids
     form_configurable :guess_mode, type: :boolean
     form_configurable :score_question_ids
+    form_configurable :use_weights, type: :boolean
     form_configurable :comment_question_ids
     form_configurable :mode, type: :array, values: %w(all on_change merge)
     form_configurable :page
@@ -153,6 +155,7 @@ module Agents
           survey['score_question_ids'] = interpolated['score_question_ids']
           survey['comment_question_ids'] = interpolated['comment_question_ids']
         end
+        survey['use_weights'] = boolify(interpolated['use_weights'])
         SurveyMonkeyParser.new(survey)
       end
     end

--- a/app/services/survey_monkey_parser.rb
+++ b/app/services/survey_monkey_parser.rb
@@ -101,11 +101,17 @@ class SurveyMonkeyParser
     end
 
     def parsed_score_answer(choice_id)
-      score_options.find { |c| c['id'] == choice_id }['text'].gsub(/[^0-9]/, '').to_i
+      choice = score_options.find { |c| c['id'] == choice_id }
+
+      if choice['weight'].present?
+        choice['weight']
+      else
+        choice['text'].gsub(/[^0-9]/, '').to_i
+      end
     end
 
     def average_score
-      total = score_answers_given.reduce(0) { |sum, answ| sum + parsed_score_answer(answ["choice_id"]) }
+      total = score_answers_given.reduce(0) { |sum, answer| sum + parsed_score_answer(answer["choice_id"]) }
       total / (score_answers_given.size.nonzero? || 1)
     end
 

--- a/app/services/survey_monkey_parser.rb
+++ b/app/services/survey_monkey_parser.rb
@@ -161,10 +161,7 @@ class SurveyMonkeyParser
     end
 
     def parsed_comment_answer
-      comments = comment_answers_given.map do |answ|
-        answ['text']
-      end
-      comments.join("\n")
+      comment_answers_given.map { |answ|  answ['text'] }.join("\n")
     end
 
     def find_question(question_ids)

--- a/app/services/survey_monkey_parser.rb
+++ b/app/services/survey_monkey_parser.rb
@@ -41,6 +41,10 @@ class SurveyMonkeyParser
       @comment_question_ids ||= (data['comment_question_ids'] || "").split(',')
     end
 
+    def use_weights
+      @use_weights ||= data['use_weights']
+    end
+
     private
 
     attr_reader :data
@@ -103,7 +107,7 @@ class SurveyMonkeyParser
     def parsed_score_answer(choice_id)
       choice = score_options.find { |c| c['id'] == choice_id }
 
-      if choice['weight'].present?
+      if survey.use_weights && choice['weight'].present?
         choice['weight']
       else
         choice['text'].gsub(/[^0-9]/, '').to_i

--- a/app/services/survey_monkey_parser.rb
+++ b/app/services/survey_monkey_parser.rb
@@ -129,7 +129,7 @@ class SurveyMonkeyParser
     def score
       return if response.score_question.blank?
       total = response.score_answers.reduce(0) { |sum, answer| sum + parsed_score_answer(answer["choice_id"]) }
-      total / (response.score_answers.size.nonzero? || 1)
+      total.fdiv(response.score_answers.size.nonzero? || 1).round
     end
 
     def comment


### PR DESCRIPTION
To get score when answers are multi rows, the agent looks for every choice_id in survey details and extract the value, then the average of all choices is calculated. Similar for comments.

https://trello.com/c/G68h8Lfu/475-add-ability-to-get-scores-for-questions-with-multiple-rows-on-surveymonkey-agent

### Event payload
Before:
```
{
  "score": 2,
  "comment": "more dresses for telephone numbers say more in contact with your customer",
  "id": "5431616232",
  "survey_id": "60926882",
  "date_created": "2017-09-23T14:56:29+00:00",
  "collector_id": "75862972",
  "custom_variables": {
  },
  "analyze_url": "https://www.surveymonkey.com/analyze/browse/rnYKfhMmvoohXEONXlb_2FTXSdkotX6xc5BfUDlX97ohg_3D?respondent_id=5431616232",
  "language": "en"
}
```
After:
```
{
  "score": 2,
  "comment": "one comment\nTwo comment",
  "id": "5431616232",
  "survey_id": "60926882",
  "date_created": "2017-09-23T14:56:29+00:00",
  "collector_id": "75862972",
  "custom_variables": {
  },
  "analyze_url": "https://www.surveymonkey.com/analyze/browse/rnYKfhMmvoohXEONXlb_2FTXSdkotX6xc5BfUDlX97ohg_3D?respondent_id=5431616232",
  "language": "en"
}
```
