### PR TITLE
Sort answers on Typeform Response payloads

### DIFF
--- a/app/models/agents/typeform_response_agent.rb
+++ b/app/models/agents/typeform_response_agent.rb
@@ -241,8 +241,8 @@ module Agents
     def transform_typeform_responses(response)
       answers = sorted_answers(response.answers)
       {
-        score: score_from_response(response),
-        comment: comment_from_response(response),
+        score: score_from_response(answers),
+        comment: comment_from_response(answers),
         created_at: response.submitted_at,
         id: response.token,
         answers: answers,
@@ -253,30 +253,30 @@ module Agents
       }
     end
 
-    def score_from_response(response)
+    def score_from_response(answers)
       answer = if boolify(interpolated['guess_mode'])
-                 response.answers.find {|h| h.field.type == "opinion_scale" }
+                 answers.find {|h| h.field.type == "opinion_scale" }
                else
-                 answer_for(response, interpolated['score_question_ids'])
+                 answer_for(answers, interpolated['score_question_ids'])
                end
 
       answer.number if answer.present?
     end
 
-    def comment_from_response(response)
+    def comment_from_response(answers)
       answer = if boolify(interpolated['guess_mode'])
-                 response.answers.find { |h| h["field"]["type"] == "long_text" }
+                 answers.find { |h| h["field"]["type"] == "long_text" }
                else
-                 answer_for(response, interpolated['comment_question_ids'])
+                 answer_for(answers, interpolated['comment_question_ids'])
                end
 
       answer.text if answer.present?
     end
 
-    def answer_for(response, option_ids)
-      answers_ids = response.answers.map {|a| a.field.id }
+    def answer_for(answers, option_ids)
+      answers_ids = answers.map {|a| a.field.id }
       key = option_ids.split(',').find { |id| answers_ids.include?(id) }
-      response.answers.find {|h| h.field.id == key }
+      answers.find {|h| h.field.id == key }
     end
 
     def transform_answers(answers)


### PR DESCRIPTION
Now the answers array is sort by field.id.
With this change, the formatted_answers field also changes in the same order as 'answers' field.

Example:
```
{
    "score": 5,
    "comment": "Clearscore is a really useful service. The fact that it fits into an app is charming.",
    "created_at": "2017-09-30T12:47:25Z",
    "id": "97d8afc6f48ae2f47be5efd6fc964a0f",
    "answers": [
      {
        "field": {
          "id": "58048049",
          "type": "opinion_scale"
        },
        "type": "number",
        "number": 10
      },
      {
        "field": {
          "id": "58048493",
          "type": "opinion_scale"
        },
        "type": "number",
        "number": 5
      },
      {
        "field": {
          "id": "58048684",
          "type": "opinion_scale"
        },
        "type": "number",
        "number": 5
      },
      {
        "field": {
          "id": "58048687",
          "type": "opinion_scale"
        },
        "type": "number",
        "number": 5
      },
      {
        "field": {
          "id": "58048690",
          "type": "opinion_scale"
        },
        "type": "number",
        "number": 1
      },
      {
        "field": {
          "id": "58048704",
          "type": "opinion_scale"
        },
        "type": "number",
        "number": 1
      },
      {
        "field": {
          "id": "58049393",
          "type": "multiple_choice"
        },
        "type": "choice",
        "choice": {
          "label": "35 to 44"
        }
      },
      {
        "field": {
          "id": "58049487",
          "type": "dropdown"
        },
        "type": "text",
        "text": "Yorkshire and Humber"
      },
      {
        "field": {
          "id": "58049765",
          "type": "dropdown"
        },
        "type": "text",
        "text": "< £20,000"
      },
      {
        "field": {
          "id": "58049969",
          "type": "long_text"
        },
        "type": "text",
        "text": "Clearscore is a really useful service. The fact that it fits into an app is charming."
      }
    ],
    "formatted_answers": {
      "opinion_scale_58048049": 10,
      "opinion_scale_58048493": 5,
      "opinion_scale_58048684": 5,
      "opinion_scale_58048687": 5,
      "opinion_scale_58048690": 1,
      "opinion_scale_58048704": 1,
      "multiple_choice_58049393": {
        "label": "35 to 44"
      },
      "dropdown_58049487": "Yorkshire and Humber",
      "dropdown_58049765": "< £20,000",
      "long_text_58049969": "Clearscore is a really useful service. The fact that it fits into an app is charming."
    },
    "metadata": {
      "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/602.3.12 (KHTML, like Gecko) Version/10.0.2 Safari/602.3.12",
      "platform": "other",
      "referer": "https://clearscore.typeform.com/to/RAb57G?name=Andrew&score=2&customer=343762&survey_name=login_monthly&survey_answer=Somewhat+disappointed&utm_medium=email&utm_campaign=research_perc_val_2017_08_12&utm_source=blueshift&utm_content=research_perc_val_2017_08_12_log_mon&bsft_clkid=80167fe9-132b-4ffd-82fd-fc49a16def21&bsft_uid=8d10b686-a7bc-49b5-92ca-b32ee9cdc295&bsft_mid=fd8a350e-1952-4889-b21b-4fccf65ad1cf&bsft_eid=91fc24f0-d98e-4b38-8135-a6cfb3c68a72",
      "network_id": "0dd2f9e340",
      "browser": "default"
    },
    "hidden_variables": {
      "customer": "343762",
      "name": "Andrew",
      "score": "2",
      "survey_answer": "Somewhat+disappointed",
      "survey_name": "login_monthly"
    },
    "mapped_variables": {
      "score": "excelent"
    }
  }
```