### PR TITLE
Add mapping functionality to the Chattermill Response agent

### DIFF
--- a/app/models/agents/chattermill_response_agent.rb
+++ b/app/models/agents/chattermill_response_agent.rb
@@ -55,6 +55,18 @@ module Agents
           * `expected_receive_period_in_days` - Specify the period in days used to calculate if the agent is working.
           * `send_batch_events` - Select `true` or `false`.
           * `max_events_per_batch` - Specify the maximum number of events that you'd like to send per batch.
+
+          If you specify `mappings` you must set up something like this:
+
+              "score": {
+                "Good, I'm satisfied": "10",
+                "Bad, I'm unsatisfied": "0"
+              },
+              "segments.segment_id.value": {
+                "Joyeux Noël": "651",
+                "Lux Letterbox Subscription": "669"
+              }
+
       MD
     end
 

--- a/app/models/agents/chattermill_response_agent.rb
+++ b/app/models/agents/chattermill_response_agent.rb
@@ -186,11 +186,16 @@ module Agents
 
     def apply_mappings(payload)
       return payload unless interpolated['mappings'].present?
-      interpolated['mappings'].each do |key, values|
-        opt = Utils.value_at(payload, key)
-        value = values[opt] || opt
-        payload.merge!("#{key}": value)
+      interpolated['mappings'].each do |path, values|
+        opt = Utils.value_at(payload, path)
+        next unless values.has_key?(opt)
+        mapped = path.split('.').reverse.each_with_index.inject({}) do |hash, (n,i)|
+          new_value = (i == 0 ? values[opt] : hash )
+          { n => new_value  }
+        end
+        payload.deep_merge!(mapped)
       end
+
       payload
     end
 


### PR DESCRIPTION
Added `mappings` option, it must be configured in the following way:

```
"mappings":   {
              "score": {
                "Good, I'm satisfied": "10",
                "Bad, I'm unsatisfied": "0"
              },
              "segments.segment_id.value": {
                "Joyeux Noël": "651",
                "Lux Letterbox Subscription": "669"
              }
}
```

### Example
To replace this agent options:
```
{
  "organization_subdomain": "{{message}}",
  "id": "",
  "comment": "{{ data['Comments/Feedback']}}",
  "score": "{{ data['Rating']| replace: \"Good, I'm satisfied\" , 10 | replace: \"Bad, I'm unsatisfied\" , 0}}",
  "kind": "csat",
  "stream": "csat_survey",
  "dataset_id": "{{message | replace: 'snagajobemployees' , 265 | replace: 'snagajob' , 266}}",
  "created_at": "{{fixed_date}}",
}
```

score and dataset_id should be:

```
"score": "{{ data['Rating'] }}",
"dataset_id": "{{ message }}"
```

You must set mapping like this:

```
{
  "dataset_id": {
    "snagajobemployees": "265",
    "snagajob": "266"
  },
  "score": {
    "Good, I'm satisfied": "10",
    "Bad, I'm unsatisfied": "0"
  }
}
```

###  Screenshots
<img width="952" alt="captura de pantalla 2018-01-15 a la s 3 08 48 p m" src="https://user-images.githubusercontent.com/922866/34957972-4271f54e-fa06-11e7-8c00-8257a4a492db.png">
<img width="558" alt="captura de pantalla 2018-01-15 a la s 3 09 04 p m" src="https://user-images.githubusercontent.com/922866/34957991-51b19424-fa06-11e7-8043-16f0f3105d37.png">

