### PR TITLE
Avoid duplicated events

### DIFF
--- a/app/models/agents/appfigures_reviews_agent.rb
+++ b/app/models/agents/appfigures_reviews_agent.rb
@@ -174,7 +174,7 @@ module Agents
     end
 
     def agent_in_process?
-      boolify(memory['in_process']) == true
+      boolify(memory['in_process'])
     end
 
     def process_agent!

--- a/app/models/agents/delighted_agent.rb
+++ b/app/models/agents/delighted_agent.rb
@@ -154,7 +154,7 @@ module Agents
     end
 
     def agent_in_process?
-      boolify(memory['in_process']) == true
+      boolify(memory['in_process'])
     end
 
     def process_agent!

--- a/app/models/agents/delighted_agent.rb
+++ b/app/models/agents/delighted_agent.rb
@@ -76,13 +76,21 @@ module Agents
     end
 
     def check
-      old_events = previous_payloads(1)
-      delighted_events.each do |e|
-        if store_payload!(old_events, e)
-          log "Storing new result for '#{name}': #{e.inspect}"
-          create_event payload: e
+      unless agent_in_process?
+        process_agent!
+        old_events = previous_payloads(1)
+        delighted_events.each do |e|
+          if store_payload!(old_events, e)
+            log "Storing new result for '#{name}': #{e.inspect}"
+            create_event payload: e
+          end
         end
+        memory['in_process'] = false
       end
+    rescue
+      memory['in_process'] = false
+      save!
+      raise
     end
 
     private
@@ -143,6 +151,15 @@ module Agents
 
     def delighted_client
       @delighted_client ||= Delighted::Client.new(api_key: interpolated['api_key'])
+    end
+
+    def agent_in_process?
+      boolify(memory['in_process']) == true
+    end
+
+    def process_agent!
+      memory['in_process'] = true
+      save!
     end
   end
 end

--- a/app/models/agents/survey_monkey_agent.rb
+++ b/app/models/agents/survey_monkey_agent.rb
@@ -197,7 +197,7 @@ module Agents
     end
 
     def agent_in_process?
-      boolify(memory['in_process']) == true
+      boolify(memory['in_process'])
     end
 
     def process_agent!

--- a/app/models/agents/survey_monkey_agent.rb
+++ b/app/models/agents/survey_monkey_agent.rb
@@ -100,14 +100,22 @@ module Agents
     end
 
     def check
-      old_events = previous_payloads(1)
-      responses = surveys.map(&:parse_responses).flatten
-      responses.each do |response|
-        if store_payload!(old_events, response)
-          log "Storing new result for '#{name}': #{response.inspect}"
-          create_event payload: response
+      unless agent_in_process?
+        process_agent!
+        old_events = previous_payloads(1)
+        responses = surveys.map(&:parse_responses).flatten
+        responses.each do |response|
+          if store_payload!(old_events, response)
+            log "Storing new result for '#{name}': #{response.inspect}"
+            create_event payload: response
+          end
         end
+        memory['in_process'] = false
       end
+    rescue
+      memory['in_process'] = false
+      save!
+      raise
     end
 
     private
@@ -186,6 +194,15 @@ module Agents
       return {} unless response.success?
 
       JSON.parse(response.body)
+    end
+
+    def agent_in_process?
+      boolify(memory['in_process']) == true
+    end
+
+    def process_agent!
+      memory['in_process'] = true
+      save!
     end
   end
 end

--- a/app/models/agents/typeform_agent.rb
+++ b/app/models/agents/typeform_agent.rb
@@ -199,7 +199,7 @@ module Agents
     end
 
     def agent_in_process?
-      boolify(memory['in_process']) == true
+      boolify(memory['in_process'])
     end
 
     def process_agent!

--- a/app/models/agents/typeform_agent.rb
+++ b/app/models/agents/typeform_agent.rb
@@ -100,13 +100,21 @@ module Agents
     end
 
     def check
-      old_events = previous_payloads(1)
-      typeform_events.each do |e|
-        if store_payload!(old_events, e)
-          log "Storing new result for '#{name}': #{e.inspect}"
-          create_event payload: e
+      unless agent_in_process?
+        process_agent!
+        old_events = previous_payloads(1)
+        typeform_events.each do |e|
+          if store_payload!(old_events, e)
+            log "Storing new result for '#{name}': #{e.inspect}"
+            create_event payload: e
+          end
         end
+        memory['in_process'] = false
       end
+    rescue
+      memory['in_process'] = false
+      save!
+      raise
     end
 
     private
@@ -188,6 +196,15 @@ module Agents
 
     def typeform
       @typeform ||= Typeform::Form.new(api_key: interpolated['api_key'], form_id: interpolated['form_id'])
+    end
+
+    def agent_in_process?
+      boolify(memory['in_process']) == true
+    end
+
+    def process_agent!
+      memory['in_process'] = true
+      save!
     end
   end
 end

--- a/app/models/agents/typeform_response_agent.rb
+++ b/app/models/agents/typeform_response_agent.rb
@@ -371,7 +371,7 @@ module Agents
     end
 
     def agent_in_process?
-      boolify(memory['in_process']) == true
+      boolify(memory['in_process'])
     end
 
     def process_agent!

--- a/app/models/agents/typeform_response_agent.rb
+++ b/app/models/agents/typeform_response_agent.rb
@@ -190,13 +190,21 @@ module Agents
     end
 
     def check
-      old_events = previous_payloads(1)
-      typeform_events.each do |e|
-        if store_payload!(old_events, e)
-          log "Storing new result for '#{name}': #{e.inspect}"
-          create_event payload: e
+      unless agent_in_process?
+        process_agent!
+        old_events = previous_payloads(1)
+        typeform_events.each do |e|
+          if store_payload!(old_events, e)
+            log "Storing new result for '#{name}': #{e.inspect}"
+            create_event payload: e
+          end
         end
+        memory['in_process'] = false
       end
+    rescue
+      memory['in_process'] = false
+      save!
+      raise
     end
 
     private
@@ -360,6 +368,15 @@ module Agents
         end
       end
       bucket
+    end
+
+    def agent_in_process?
+      boolify(memory['in_process']) == true
+    end
+
+    def process_agent!
+      memory['in_process'] = true
+      save!
     end
   end
 end

--- a/app/models/agents/usabilla_agent.rb
+++ b/app/models/agents/usabilla_agent.rb
@@ -290,7 +290,7 @@ module Agents
     end
 
     def agent_in_process?
-      boolify(memory['in_process']) == true
+      boolify(memory['in_process'])
     end
 
     def process_agent!

--- a/app/models/agents/usabilla_agent.rb
+++ b/app/models/agents/usabilla_agent.rb
@@ -125,21 +125,29 @@ module Agents
     end
 
     def check
-      events = []
-      events += retrieve_buttons if retrieve_buttons?
-      events += retrieve_apps if retrieve_apps?
-      events += retrieve_emails if retrieve_emails?
-      events += retrieve_campaigns if retrieve_campaigns?
+      unless agent_in_process?
+        process_agent!
+        events = []
+        events += retrieve_buttons if retrieve_buttons?
+        events += retrieve_apps if retrieve_apps?
+        events += retrieve_emails if retrieve_emails?
+        events += retrieve_campaigns if retrieve_campaigns?
 
-      old_events = previous_payloads(1)
+        old_events = previous_payloads(1)
 
-      events.each do |e|
-        payload = usabilla_response_to_event(e)
-        if store_payload!(old_events, payload)
-          log "Storing new result for '#{name}': #{payload.inspect}"
-          create_event payload: payload
+        events.each do |e|
+          payload = usabilla_response_to_event(e)
+          if store_payload!(old_events, payload)
+            log "Storing new result for '#{name}': #{payload.inspect}"
+            create_event payload: payload
+          end
         end
+        memory['in_process'] = false
       end
+    rescue
+      memory['in_process'] = false
+      save!
+      raise
     end
 
     private
@@ -279,6 +287,15 @@ module Agents
 
     def usabilla_api
       UsabillaApi
+    end
+
+    def agent_in_process?
+      boolify(memory['in_process']) == true
+    end
+
+    def process_agent!
+      memory['in_process'] = true
+      save!
     end
   end
 end


### PR DESCRIPTION
This fix allows to one only agent instance to check at the same time, avoiding duplicated events and further improving the performance.
