### PR TITLE
Fix full_response hash on SurveyMonkey

### DIFF
--- a/app/services/survey_monkey_parser.rb
+++ b/app/services/survey_monkey_parser.rb
@@ -159,18 +159,20 @@ class SurveyMonkeyParser
       choices = details.dig('answers','choices')
 
       question['answers']&.each_with_object({}) do |a, hsh|
-        if a['choice_id'].present? && a['row_id'].present?
-          row = rows&.find { |r| r['id'] == a['row_id'] }
-          choice = choices&.find { |c| c['id'] == a['choice_id'] }
+        row = rows&.find { |r| r['id'] == a['row_id'] }['text'] if a['row_id'].present?
+        key = row || heading
+        value = extract_text_from_answer(a, choices)
 
-          hsh[row['text']] = choice['text']
-        elsif a['choice_id'].present?
-          choice = choices&.find { |c| c['id'] == a['choice_id'] }
+        hsh[key] = hsh[key].blank? ? value : "#{hsh[key].to_s}, #{value}"
+      end
+    end
 
-          hsh[heading] = choice['text']
-        else
-          hsh[heading] = a['text']
-        end
+    def extract_text_from_answer(answer, choices)
+      if answer['choice_id'].present?
+        choice = choices&.find { |c| c['id'] == answer['choice_id'] }
+        choice['text']
+      else
+        answer['text']
       end
     end
 


### PR DESCRIPTION
### Examples

Multi answers with row text:
```
      "247300627": {
        "id": "247300627",
        "family": "open_ended",
        "subtype": "multi",
        "question": "How can we contact you 2?",
        "answers": {
          "Phone": "5566778899",
          "Email": "myemail2@example.com"
        }
      },
      "244148990": {
        "id": "244148990",
        "family": "matrix",
        "subtype": "rating",
        "question": "How satisfied are you with the answer you received?",
        "answers": {
          "Time of answer": "Completely satisfied",
          "Easy to understand": "Satisfied",
          "Complete": "Not fully satisfied"
        }
      },
```

Multi answers without row text:
```
      "234230463": {
        "id": "234230463",
        "family": "multiple_choice",
        "subtype": "vertical",
        "question": "Which of the following words would you use to describe our products? Select all that apply.",
        "answers": {
          "Which of the following words would you use to describe our products? Select all that apply.": "High quality , Useful, Good value for money, Impractical, Poor quality"
        }
      },
```