### PR TITLE
Add uniqueness look back option

### DIFF
--- a/app/models/agents/survey_monkey_agent.rb
+++ b/app/models/agents/survey_monkey_agent.rb
@@ -4,7 +4,7 @@ module Agents
     include FormConfigurable
 
     UNIQUENESS_LOOK_BACK = 500
-    UNIQUENESS_FACTOR = 5
+    UNIQUENESS_FACTOR = 1
     HTTP_METHOD = "get"
     SURVEYS_URL_BASE = "https://api.surveymonkey.net/v3/surveys"
 
@@ -31,6 +31,7 @@ module Agents
           * `guess_mode` - Let the agent try to figure out the score question and the comment question automatically.
           * `score_question_ids` - Hard-code the comma separated list of ids of the score questions (agent will pick the first one present) if `guess_mode` is off
           * `comment_question_ids` - Hard-code he comma separated list of ids of the comment questions (agent will pick the first one present) if `guess_mode` is off
+          * `uniqueness_look_back` - Set the limit the number of events checked for uniqueness (typically for performance).  This defaults to the larger of #{UNIQUENESS_LOOK_BACK} or #{UNIQUENESS_FACTOR}x the number of detected received results.
           * `expected_update_period_in_days` - Specify the period in days used to calculate if the agent is working.
       MD
     end
@@ -76,6 +77,7 @@ module Agents
     form_configurable :mode, type: :array, values: %w(all on_change merge)
     form_configurable :page
     form_configurable :per_page
+    form_configurable :uniqueness_look_back
     form_configurable :expected_update_period_in_days
 
     def validate_options
@@ -98,14 +100,18 @@ module Agents
         errors.add(:base, "comment_question_ids option is required") if options['comment_question_ids'].blank?
       end
 
+      if options['uniqueness_look_back'].present?
+        errors.add(:base, "Invalid uniqueness_look_back format") unless (options['uniqueness_look_back']).to_i.positive?
+      end
+
       validate_web_request_options!
     end
 
     def check
       unless agent_in_process?
         process_agent!
-        old_events = previous_payloads(1)
         responses = surveys.map(&:parse_responses).flatten
+        old_events = previous_payloads(responses.count)
         responses.each do |response|
           if store_payload!(old_events, response)
             log "Storing new result for '#{name}': #{response.inspect}"
@@ -127,9 +133,13 @@ module Agents
     end
 
     def previous_payloads(num_events)
-      # Larger of UNIQUENESS_FACTOR * num_events and UNIQUENESS_LOOK_BACK
-      look_back = UNIQUENESS_FACTOR * num_events
-      look_back = UNIQUENESS_LOOK_BACK if look_back < UNIQUENESS_LOOK_BACK
+      if interpolated['uniqueness_look_back'].present?
+        look_back = interpolated['uniqueness_look_back'].to_i
+      else
+        # Larger of UNIQUENESS_FACTOR * num_events and UNIQUENESS_LOOK_BACK
+        look_back = UNIQUENESS_FACTOR * num_events
+        look_back = UNIQUENESS_LOOK_BACK if look_back < UNIQUENESS_LOOK_BACK
+      end
 
       events.order('id desc nulls last').limit(look_back) if interpolated['mode'] == 'on_change'
     end

--- a/app/models/agents/typeform_agent.rb
+++ b/app/models/agents/typeform_agent.rb
@@ -5,7 +5,7 @@ module Agents
     include FormConfigurable
 
     UNIQUENESS_LOOK_BACK = 500
-    UNIQUENESS_FACTOR = 5
+    UNIQUENESS_FACTOR = 1
 
     gem_dependency_check { defined?(Typeform) }
 
@@ -32,7 +32,8 @@ module Agents
         * `comment_question_ids` - Hard-code he comma separated list of ids of the comment questions (agent will pick the first one present) if `guess_mode` is off
         * `expected_receive_period_in_days` - Specify the period in days used to calculate if the agent is working.
         * `limit` - Number of responses to fetch per run, better to set to a low number nad have the agent run more often.
-        * `offset` - Number of responses to offset by if you want to go back in the past
+        * `offset` - Number of responses to offset by if you want to go back in the past.
+        * `uniqueness_look_back` - Set the limit the number of events checked for uniqueness (typically for performance).  This defaults to the larger of #{UNIQUENESS_LOOK_BACK} or #{UNIQUENESS_FACTOR}x the number of detected received results.
     MD
 
     event_description <<-MD
@@ -78,6 +79,7 @@ module Agents
     form_configurable :limit
     form_configurable :offset
     form_configurable :mode, type: :array, values: %w[all on_change merge]
+    form_configurable :uniqueness_look_back
     form_configurable :expected_update_period_in_days
 
     def default_options
@@ -120,9 +122,13 @@ module Agents
     private
 
     def previous_payloads(num_events)
-      # Larger of UNIQUENESS_FACTOR * num_events and UNIQUENESS_LOOK_BACK
-      look_back = UNIQUENESS_FACTOR * num_events
-      look_back = UNIQUENESS_LOOK_BACK if look_back < UNIQUENESS_LOOK_BACK
+      if interpolated['uniqueness_look_back'].present?
+        look_back = interpolated['uniqueness_look_back'].to_i
+      else
+        # Larger of UNIQUENESS_FACTOR * num_events and UNIQUENESS_LOOK_BACK
+        look_back = UNIQUENESS_FACTOR * num_events
+        look_back = UNIQUENESS_LOOK_BACK if look_back < UNIQUENESS_LOOK_BACK
+      end
 
       events.order('id desc nulls last').limit(look_back) if interpolated['mode'] == 'on_change'
     end

--- a/app/models/agents/typeform_response_agent.rb
+++ b/app/models/agents/typeform_response_agent.rb
@@ -6,7 +6,7 @@ module Agents
     include FormConfigurable
 
     UNIQUENESS_LOOK_BACK = 500
-    UNIQUENESS_FACTOR = 5
+    UNIQUENESS_FACTOR = 1
 
     gem_dependency_check { defined?(Typeform) }
 
@@ -39,6 +39,7 @@ module Agents
         * `until` - Specify date and time, to limit request to responses submitted until the specified date and time, e.g. `1979-05-27 05:00:00`, `January 5 at 7pm` [more valid formats](https://github.com/mojombo/chronic).
         * `mapping_object` - Specify the mapping definition object where any hidden_variables can be mapped with a single value.
         * `bucketing_object` - Specify the bucketing definition object where any hidden_variables can be broken into a specific bucket.
+        * `uniqueness_look_back` - Set the limit the number of events checked for uniqueness (typically for performance).  This defaults to the larger of #{UNIQUENESS_LOOK_BACK} or #{UNIQUENESS_FACTOR}x the number of detected received results.
 
         If you specify `mapping_object` you must set up something like this:
 
@@ -160,6 +161,7 @@ module Agents
     form_configurable :mapping_object, type: :json, ace: { mode: 'json' }
     form_configurable :bucketing_object, type: :json, ace: { mode: 'json' }
     form_configurable :mode, type: :array, values: %w[all on_change merge]
+    form_configurable :uniqueness_look_back
     form_configurable :expected_update_period_in_days
 
     def default_options
@@ -202,9 +204,13 @@ module Agents
     private
 
     def previous_payloads(num_events)
-      # Larger of UNIQUENESS_FACTOR * num_events and UNIQUENESS_LOOK_BACK
-      look_back = UNIQUENESS_FACTOR * num_events
-      look_back = UNIQUENESS_LOOK_BACK if look_back < UNIQUENESS_LOOK_BACK
+      if interpolated['uniqueness_look_back'].present?
+        look_back = interpolated['uniqueness_look_back'].to_i
+      else
+        # Larger of UNIQUENESS_FACTOR * num_events and UNIQUENESS_LOOK_BACK
+        look_back = UNIQUENESS_FACTOR * num_events
+        look_back = UNIQUENESS_LOOK_BACK if look_back < UNIQUENESS_LOOK_BACK
+      end
 
       events.order('id desc nulls last').limit(look_back) if interpolated['mode'] == 'on_change'
     end


### PR DESCRIPTION
Set the `uniqueness_look_back` to limit the number of events checked for uniqueness.  Defaults to the larger of 500 or the number of detected received results.

### Screenshots

<img width="653" alt="image2" src="https://user-images.githubusercontent.com/922866/35349628-de4709e8-0111-11e8-9963-77ef72bc394e.png">
