### PR TITLE
Fix Appfigure Review agent

### DIFF
--- a/app/models/agents/appfigures_reviews_agent.rb
+++ b/app/models/agents/appfigures_reviews_agent.rb
@@ -147,6 +147,8 @@ module Agents
     end
 
     def fetch_resource
+      return unless request_url.present?
+
       log "Fetching reviews for products: #{options['products']}"
       response = faraday.get(request_url)
       unless response.success?
@@ -157,15 +159,17 @@ module Agents
     end
 
     def request_url
+      return unless params.present?
       url = APPFIGURES_URL_BASE
-      url << "?#{params}" if params.present?
+      url << "?#{params}"
       url
     end
 
     def params
-      query_string = []
+      return unless options['products'].present?
+
+      query_string = ["products=#{options['products']}"]
       query_string << options['filter'] if options['filter'].present?
-      query_string << "products=#{options['products']}" if options['products'].present?
       query_string.join('&')
     end
 


### PR DESCRIPTION
Sometimes reviews from one AppFigures agent end up in a different AppFigures agent’s stream. It's possible that the products options may be missing in some cases. When  Appfigure endpoint doesn't have a products param, you get all reviews of all products in the account

This PR aims to avoid fetching reviews of all products in the account.
