### PR TITLE
Add task to clean in_process flag on agents memory

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -3,7 +3,7 @@
 ###############################
 
 # Procfile for development using the new threaded worker (scheduler, twitter stream and delayed job)
-web: bundle exec rails server -p ${PORT-3000} -b ${IP-0.0.0.0}
+web: bundle exec rake agents:clean_in_process_memory && rails server -p ${PORT-3000} -b ${IP-0.0.0.0}
 jobs: bundle exec rails runner bin/threaded.rb
 
 # Old version with separate processes (use this if you have issues with the threaded version)

--- a/lib/tasks/clean_agents_memory.rake
+++ b/lib/tasks/clean_agents_memory.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :agents do
+  desc 'set in_process flag to false for some agents'
+  task clean_in_process_memory: :environment do
+    agents = %W[AppfiguresReviewsAgent ChattermillResponseAgent DelightedAgent SurveyMonkeyAgent TypeformAgent TypeformResponseAgent UsabillaAgent]
+
+    agents.each do |a|
+      puts "Setting #{a} agents"
+      klass = "Agents::#{a}".constantize
+      klass.all.each do |agent|
+        agent.memory['in_process'] = false
+        agent.save!
+      end
+    end
+    puts 'Done!'
+  end
+end

--- a/lib/tasks/clean_agents_memory.rake
+++ b/lib/tasks/clean_agents_memory.rake
@@ -3,12 +3,12 @@
 namespace :agents do
   desc 'set in_process flag to false for some agents'
   task clean_in_process_memory: :environment do
-    agents = %W[AppfiguresReviewsAgent ChattermillResponseAgent DelightedAgent SurveyMonkeyAgent TypeformAgent TypeformResponseAgent UsabillaAgent]
+    agent_classes = %w[AppfiguresReviewsAgent ChattermillResponseAgent DelightedAgent SurveyMonkeyAgent TypeformAgent TypeformResponseAgent UsabillaAgent]
 
-    agents.each do |a|
+    agent_classes.each do |a|
       puts "Setting #{a} agents"
       klass = "Agents::#{a}".constantize
-      klass.all.each do |agent|
+      klass.find_each do |agent|
         agent.memory['in_process'] = false
         agent.save!
       end


### PR DESCRIPTION
When the server goes down / stops and there are jobs running, the in_process flag remains true, this rake task allows to clean that flag on some agents