### PR TITLE
Events deduplication improvements - Part I

### DIFF
--- a/app/concerns/deduplication_concern.rb
+++ b/app/concerns/deduplication_concern.rb
@@ -1,0 +1,43 @@
+
+module DeduplicationConcern
+  extend ActiveSupport::Concern
+
+  def previous_payloads(events_amount)
+    if interpolated['uniqueness_look_back'].present?
+      look_back = interpolated['uniqueness_look_back'].to_i
+    else
+      # Larger of UNIQUENESS_FACTOR * num_events and UNIQUENESS_LOOK_BACK
+      uniqueness_look_back = self.class.const_get(:UNIQUENESS_LOOK_BACK) || 0
+      factor = self.class.const_get(:UNIQUENESS_FACTOR) || 1
+      look_back = events_amount * factor
+      if look_back < uniqueness_look_back
+        look_back = uniqueness_look_back
+      end
+    end
+    tokens.limit(look_back) if interpolated['mode'] == "on_change"
+  end
+
+  # This method returns true if the result should be stored as a new event.
+  # If mode is set to 'on_change', this method may return false and update an existing
+  # event to expire further in the future.
+  def store_payload?(old_events, payload)
+    case interpolated['mode'].presence
+    when 'on_change'
+      token = payload_to_sha(payload)
+      if found = old_events.find { |e| e.token == token }
+        found.event.update!(expires_at: new_event_expiration_date)
+        false
+      else
+        true
+      end
+    when 'all', 'merge', ''
+      true
+    else
+      raise "Illegal options[mode]: #{interpolated['mode']}"
+    end
+  end
+
+  def payload_to_sha(payload)
+    Digest::SHA256.hexdigest(payload.to_json)
+  end
+end

--- a/app/controllers/agents_controller.rb
+++ b/app/controllers/agents_controller.rb
@@ -77,6 +77,7 @@ class AgentsController < ApplicationController
 
   def remove_events
     @agent = current_user.agents.find(params[:id])
+    @agent.tokens.destroy_all
     @agent.events.delete_all
 
     respond_to do |format|

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -42,6 +42,7 @@ class Agent < ActiveRecord::Base
   before_save :unschedule_if_cannot_schedule
   before_create :set_last_checked_event_id
   after_save :possibly_update_event_expirations
+  before_destroy :delete_tokens
 
   belongs_to :user, :inverse_of => :agents
   belongs_to :service, :inverse_of => :agents, optional: true
@@ -59,6 +60,7 @@ class Agent < ActiveRecord::Base
   has_many :control_targets, through: :control_links_as_controller, class_name: "Agent", inverse_of: :controllers
   has_many :scenario_memberships, :dependent => :destroy, :inverse_of => :agent
   has_many :scenarios, :through => :scenario_memberships, :inverse_of => :agents
+  has_many :tokens, inverse_of: :agent, class_name: "DeduplicationToken"
 
   scope :active,   -> { where(disabled: false, deactivated: false) }
   scope :inactive, -> { where(['disabled = ? OR deactivated = ?', true, true]) }
@@ -261,17 +263,21 @@ class Agent < ActiveRecord::Base
   def possibly_update_event_expirations
     update_event_expirations! if saved_change_to_keep_events_for?
   end
-  
+
+  def delete_tokens
+    tokens.destroy_all
+  end
+
   #Validation Methods
-  
+
   private
-  
+
   def validate_schedule
     unless cannot_be_scheduled?
       errors.add(:schedule, "is not a valid schedule") unless SCHEDULES.include?(schedule.to_s)
     end
   end
-  
+
   def validate_options
     # Implement me in your subclass to test for valid options.
   end

--- a/app/models/deduplication_token.rb
+++ b/app/models/deduplication_token.rb
@@ -1,0 +1,13 @@
+class DeduplicationToken < ActiveRecord::Base
+  belongs_to :agent
+  belongs_to :event
+
+  validates_presence_of :token, :agent, :event
+
+  scope :expired,  -> { where("created_at < ?", 3.months.ago) }
+  default_scope { order("id desc") }
+
+  def self.cleanup_expired!
+    DeduplicationToken.expired.destroy_all
+  end
+end

--- a/db/migrate/20180320151120_create_deduplication_tokens.rb
+++ b/db/migrate/20180320151120_create_deduplication_tokens.rb
@@ -1,0 +1,11 @@
+class CreateDeduplicationTokens < ActiveRecord::Migration[5.1]
+  def change
+    create_table :deduplication_tokens do |t|
+      t.string :token
+      t.integer :agent_id
+    end
+
+    add_index :deduplication_tokens, [:agent_id, :token]
+    add_index :deduplication_tokens, :agent_id
+  end
+end

--- a/db/migrate/20180326205130_add_event_id_to_deduplication_tokens.rb
+++ b/db/migrate/20180326205130_add_event_id_to_deduplication_tokens.rb
@@ -1,0 +1,10 @@
+class AddEventIdToDeduplicationTokens < ActiveRecord::Migration[5.1]
+  def change
+    change_table :deduplication_tokens do |t|
+      t.integer :event_id
+      t.index :event_id
+    end
+
+    add_foreign_key :deduplication_tokens, :events
+  end
+end

--- a/db/migrate/20180404144553_change_deduplication_tokens.rb
+++ b/db/migrate/20180404144553_change_deduplication_tokens.rb
@@ -1,0 +1,8 @@
+class ChangeDeduplicationTokens < ActiveRecord::Migration[5.1]
+  def change
+    change_table :deduplication_tokens do |t|
+      t.datetime :created_at
+      t.index :created_at
+    end
+  end
+end

--- a/db/migrate/20180405144934_migrate_payloads_to_tokens.rb
+++ b/db/migrate/20180405144934_migrate_payloads_to_tokens.rb
@@ -1,0 +1,35 @@
+class MigratePayloadsToTokens < ActiveRecord::Migration[5.1]
+  def up
+
+    agents = [
+      "Agents::TypeformAgent",
+      "Agents::WebsiteAgent",
+      "Agents::AppfiguresReviewsAgent",
+      "Agents::ZendeskSatisfactionRatingsAgent",
+      "Agents::TypeformResponseAgent",
+      "Agents::SurveyMonkeyAgent",
+      "Agents::GooglePlayReviewsAgent",
+      "Agents::UsabillaAgent",
+      "Agents::DelightedAgent" ].freeze
+
+    agents.each do |a|
+
+      klass = a.constantize
+      klass.all.each do |agent|
+        events = agent.events.where("created_at > ?", 1.month.ago).limit(uniqueness_look_back(agent))
+        events.reverse_each do |e|
+          e.create_token!(agent: agent, token: Digest::SHA256.hexdigest(e.payload.to_json))
+        end
+      end
+    end
+  end
+
+  def down
+    DeduplicationToken.destroy_all
+  end
+
+  def uniqueness_look_back(agent)
+    return agent.interpolated['uniqueness_look_back'].to_i if agent.interpolated['uniqueness_look_back'].present?
+    agent.class.const_get(:UNIQUENESS_LOOK_BACK)
+  end
+end

--- a/lib/tasks/deduplication.rake
+++ b/lib/tasks/deduplication.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :deduplication do
+
+  desc 'Remove old tokens'
+  task remove_old_tokens: :environment do
+    DeduplicationToken.cleanup_expired!
+    puts 'Done!'
+  end
+end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -944,6 +944,22 @@ describe Agent do
       }.not_to change { agent2.events.count }
     end
   end
+
+  describe "after destroy" do
+    it "remove deduplication tokens" do
+      agent = agents(:bob_manual_event_agent)
+      event1 = agent.create_event :payload => { 'hi' => 'there' }
+      event2 = agent.create_event :payload => { 'hello' => 'there' }
+
+      expect(agent.events.count).to eq(2)
+      expect(agent.tokens.count).to eq(2)
+
+      agent.destroy
+
+      expect(agent.events.count).to eq(0)
+      expect(agent.tokens.count).to eq(0)
+    end
+  end
 end
 
 describe AgentDrop do

--- a/spec/models/agents/website_agent_spec.rb
+++ b/spec/models/agents/website_agent_spec.rb
@@ -625,6 +625,7 @@ describe Agents::WebsiteAgent do
         expect(@checker.reload).not_to be_working # There is a recent error
 
         stubbed_time = 20.minutes.from_now
+        @checker.tokens.destroy_all
         @checker.events.delete_all
         @checker.check
         expect(@checker.reload).to be_working # There is a newer event now

--- a/spec/models/deduplication_token_spec.rb
+++ b/spec/models/deduplication_token_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+describe DeduplicationToken do
+  describe "validations" do
+    before do
+      event = events(:bob_website_agent_event)
+      event.save!
+
+      @token = DeduplicationToken.new(:agent => agents(:jane_website_agent), :token => "a402f13618854bc6538f38c6a9f05eff64af6b20f41cfa9e3267691035769539", event: event)
+      expect(@token).to be_valid
+    end
+
+    it "requires an agent" do
+      @token.agent = nil
+      expect(@token).not_to be_valid
+      expect(@token).to have(2).error_on(:agent)
+    end
+
+    it "requires an event" do
+      @token.event = nil
+      expect(@token).not_to be_valid
+      expect(@token).to have(2).error_on(:event)
+    end
+
+    it "requires a token" do
+      @token.token = ""
+      expect(@token).not_to be_valid
+      expect(@token).to have(1).error_on(:token)
+    end
+  end
+
+  describe "scopes" do
+    it "return expired tokens" do
+      event = agents(:jane_rain_notifier_agent).create_event(payload: {"hi": "there"})
+      agents(:jane_rain_notifier_agent).create_event(payload: {"hello": "there"})
+
+      DeduplicationToken.last.update!(created_at: 3.months.ago)
+
+      expect(DeduplicationToken.expired.count).to eq(1)
+      expect(DeduplicationToken.expired.first.event_id).to eq(event.id)
+    end
+
+    it 'returns tokens in desc order' do
+      event1 = agents(:jane_rain_notifier_agent).create_event(payload: {"key": "one"})
+      event2 = agents(:jane_rain_notifier_agent).create_event(payload: {"key": "two"})
+      event3 = agents(:jane_rain_notifier_agent).create_event(payload: {"key": "three"})
+
+      tokens_ids = agents(:jane_rain_notifier_agent).tokens.all.map(&:id)
+
+      expect( agents(:jane_rain_notifier_agent).tokens.first).to eq(event3.token)
+      expect(tokens_ids).to eq([event3.token.id, event2.token.id, event1.token.id])
+    end
+  end
+
+  describe "#cleanup_expired" do
+    it "destroy all expired tokens" do
+      event1 = agents(:jane_rain_notifier_agent).create_event(payload: {"hi": "there"})
+      event2 = agents(:jane_rain_notifier_agent).create_event(payload: {"hello": "there"})
+      DeduplicationToken.last.update!(created_at: 3.months.ago)
+
+      expect(DeduplicationToken.count).to eq(2)
+
+      DeduplicationToken.cleanup_expired!
+
+      expect(DeduplicationToken.count).to eq(1)
+      expect(DeduplicationToken.first.id).to eq(event2.token.id)
+    end
+  end
+end


### PR DESCRIPTION
This PR  add all migrations to create the new tokens table and preload the tokens corresponding to the last events of the agents; before deploy the new way of looking for duplicates that will be implemented in this another PR:  https://github.com/chattermill/huginn/pull/103